### PR TITLE
CacheStats for FUSE filesystem hot cache & Http preview server

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -176,12 +176,22 @@ VAUL_PG_PASS=$(openssl rand -base64 32 | tr -d '\n')
 echo "🔐 Creating PostgreSQL user and database..."
 
 sudo -u postgres psql -tc "SELECT 1 FROM pg_roles WHERE rolname='vaulthalla'" | grep -q 1 ||
-    sudo -u postgres psql -c "CREATE USER vaulthalla WITH PASSWORD '${VAUL_PG_PASS}';"
+  sudo -u postgres psql -c "CREATE USER vaulthalla WITH PASSWORD '${VAUL_PG_PASS}';"
 
 sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname='vaulthalla'" | grep -q 1 ||
-    sudo -u postgres psql -c "CREATE DATABASE vaulthalla OWNER vaulthalla;"
+  sudo -u postgres psql -c "CREATE DATABASE vaulthalla OWNER vaulthalla;"
 
 sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE vaulthalla TO vaulthalla;"
+sudo -u postgres psql -d vaulthalla -c "GRANT USAGE, CREATE ON SCHEMA public TO vaulthalla;"
+
+if [[ "$DEV_MODE" == true ]]; then
+  sudo -u postgres psql -tc "SELECT 1 FROM pg_database WHERE datname='vh_cli_test'" | grep -q 1 ||
+    sudo -u postgres psql -c "CREATE DATABASE vh_cli_test OWNER vaulthalla_test;"
+
+  sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE vh_cli_test TO vaulthalla_test;"
+  sudo -u postgres psql -d vh_cli_test -c "GRANT USAGE, CREATE ON SCHEMA public TO vaulthalla_test;"
+fi
+
 
 # === 9) Seed DB Password (for runtime TPM sealing) ===
 PENDING_DB_PASS_FILE="/run/vaulthalla/db_password"

--- a/include/protocols/http/HttpRouter.hpp
+++ b/include/protocols/http/HttpRouter.hpp
@@ -4,7 +4,6 @@
 
 #include <boost/beast/http.hpp>
 #include <memory>
-#include <filesystem>
 
 namespace vh::auth {
 class AuthManager;
@@ -42,10 +41,6 @@ private:
 
     std::shared_ptr<ImagePreviewHandler> imagePreviewHandler_;
     std::shared_ptr<PdfPreviewHandler> pdfPreviewHandler_;
-
-    PreviewResponse handleCachedPreview(const std::shared_ptr<storage::StorageEngine>& engine,
-                             const std::shared_ptr<types::File>& file,
-                             const http::request<http::string_body>& req, unsigned int size) const;
 };
 
 }

--- a/include/protocols/http/HttpRouter.hpp
+++ b/include/protocols/http/HttpRouter.hpp
@@ -3,16 +3,9 @@
 #include "protocols/http/PreviewResponse.hpp"
 
 #include <boost/beast/http.hpp>
+#include <boost/beast/http/file_body.hpp>
 #include <memory>
-
-namespace vh::auth {
-class AuthManager;
-}
-
-namespace vh::storage {
-class StorageManager;
-class StorageEngine;
-}
+#include <string>
 
 namespace vh::types {
 struct File;
@@ -21,26 +14,27 @@ struct File;
 namespace vh::http {
 
 class HttpSession;
-class ImagePreviewHandler;
-class PdfPreviewHandler;
 
 namespace http = boost::beast::http;
 
-class HttpRouter {
-public:
-    HttpRouter();
+struct HttpRouter {
+    static PreviewResponse route(http::request<http::string_body>&& req);
 
-    PreviewResponse route(http::request<http::string_body>&& req) const;
+    static PreviewResponse makeResponse(const http::request<http::string_body>& req,
+                                        std::vector<uint8_t>&& data,
+                                        const std::string& mime_type,
+                                        bool cacheHit = false);
 
-    static http::response<http::string_body> makeErrorResponse(const http::request<http::string_body>& req,
-                                                               const std::string& msg);
+    static PreviewResponse makeResponse(const http::request<http::string_body>& req,
+                                        http::file_body::value_type data,
+                                        const std::string& mime_type,
+                                        bool cacheHit = false);
 
-private:
-    std::shared_ptr<auth::AuthManager> authManager_;
-    std::shared_ptr<storage::StorageManager> storageManager_;
+    static PreviewResponse makeErrorResponse(const http::request<http::string_body>& req,
+                                             const std::string& msg,
+                                             const http::status& status = http::status::not_found);
 
-    std::shared_ptr<ImagePreviewHandler> imagePreviewHandler_;
-    std::shared_ptr<PdfPreviewHandler> pdfPreviewHandler_;
+    static std::string authenticateRequest(const http::request<http::string_body>& req);
 };
 
 }

--- a/include/protocols/http/HttpServer.hpp
+++ b/include/protocols/http/HttpServer.hpp
@@ -15,7 +15,6 @@ namespace beast = boost::beast;
 namespace http = beast::http;
 namespace net = boost::asio;
 using tcp = net::ip::tcp;
-class HttpRouter;
 
 class HttpServer : public std::enable_shared_from_this<HttpServer> {
 public:
@@ -28,7 +27,6 @@ private:
 
     tcp::acceptor acceptor_;
     tcp::socket socket_;
-    std::shared_ptr<HttpRouter> router_;
     std::shared_ptr<auth::AuthManager> authManager_;
     std::shared_ptr<storage::StorageManager> storageManager_;
 };

--- a/include/protocols/http/HttpSession.hpp
+++ b/include/protocols/http/HttpSession.hpp
@@ -9,16 +9,13 @@ namespace vh::auth { class AuthManager; }
 namespace vh::storage { class StorageManager; }
 namespace vh::http {
 
-class HttpRouter;
-
 namespace beast = boost::beast;
 namespace http = beast::http;
 using tcp = boost::asio::ip::tcp;
 
 class HttpSession : public std::enable_shared_from_this<HttpSession> {
 public:
-    HttpSession(tcp::socket socket,
-                std::shared_ptr<HttpRouter> router);
+    HttpSession(tcp::socket socket);
 
     void run();
 
@@ -32,7 +29,6 @@ private:
     beast::flat_buffer buffer_;
     http::request<http::string_body> req_;
 
-    std::shared_ptr<HttpRouter> router_;
     std::shared_ptr<auth::AuthManager> auth_;
     std::shared_ptr<storage::StorageManager> storage_;
 };

--- a/include/protocols/http/PreviewRequest.hpp
+++ b/include/protocols/http/PreviewRequest.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <unordered_map>
+#include <memory>
+
+namespace vh::storage {
+struct StorageEngine;
+}
+
+namespace vh::types {
+struct File;
+}
+
+namespace vh::http {
+
+struct PreviewRequest {
+    unsigned int vault_id;
+    std::filesystem::path rel_path;
+    std::optional<unsigned int> size;
+    std::optional<float> scale;
+    std::shared_ptr<storage::StorageEngine> engine{nullptr};
+    std::shared_ptr<types::File> file{nullptr};
+
+    explicit PreviewRequest(const std::unordered_map<std::string, std::string>& params) {
+        if (!params.contains("vault_id") || !params.contains("path"))
+            throw std::invalid_argument("Missing vault_id or path");
+
+        vault_id = std::stoul(params.at("vault_id"));
+        rel_path = std::filesystem::path(params.at("path"));
+
+        if (params.contains("size"))
+            if (const unsigned int s = std::stoul(params.at("size")); s > 0) size = s;
+
+        if (params.contains("scale"))
+            if (const float s = std::stof(params.at("scale")); s > 0) scale = s;
+    }
+
+    [[nodiscard]] std::optional<std::string> sizeStr() const {
+        if (!size) return std::nullopt;
+        return std::to_string(size.value());
+    }
+
+    [[nodiscard]] std::optional<std::string> scaleStr() const {
+        if (!scale) return std::nullopt;
+        return std::to_string(scale.value());
+    }
+};
+
+
+}

--- a/include/protocols/http/handlers/ImagePreviewHandler.hpp
+++ b/include/protocols/http/handlers/ImagePreviewHandler.hpp
@@ -4,26 +4,15 @@
 
 #include <boost/beast/http.hpp>
 #include <memory>
-#include <unordered_map>
-#include <string>
-
-namespace vh::storage { class StorageManager; }
 
 namespace vh::http {
 
 namespace http = boost::beast::http;
 
-class ImagePreviewHandler {
-public:
-    explicit ImagePreviewHandler(const std::shared_ptr<storage::StorageManager>& storage) : storageManager_(storage) {}
+struct PreviewRequest;
 
-    PreviewResponse handle(http::request<http::string_body>&& req,
-                                          int vault_id,
-                                          const std::string& rel_path,
-                                          const std::unordered_map<std::string, std::string>& params) const;
-
-private:
-    std::shared_ptr<storage::StorageManager> storageManager_;
+struct ImagePreviewHandler {
+    static PreviewResponse handle(http::request<http::string_body>&& req, const std::unique_ptr<PreviewRequest>&& pr);
 };
 
 }

--- a/include/protocols/http/handlers/PdfPreviewHandler.hpp
+++ b/include/protocols/http/handlers/PdfPreviewHandler.hpp
@@ -4,26 +4,15 @@
 
 #include <boost/beast/http.hpp>
 #include <memory>
-#include <unordered_map>
-#include <string>
-
-namespace vh::storage { class StorageManager; }
 
 namespace vh::http {
 
 namespace http = boost::beast::http;
 
-class PdfPreviewHandler {
-public:
-    explicit PdfPreviewHandler(const std::shared_ptr<storage::StorageManager>& storage) : storageManager_(storage) {}
+struct PreviewRequest;
 
-    PreviewResponse handle(http::request<http::string_body>&& req,
-                           int vault_id,
-                           const std::string& rel_path,
-                           const std::unordered_map<std::string, std::string>& params) const;
-
-private:
-    std::shared_ptr<storage::StorageManager> storageManager_;
+struct PdfPreviewHandler {
+    static PreviewResponse handle(http::request<http::string_body>&& req, const std::unique_ptr<PreviewRequest>&& pr);
 };
 
 }

--- a/include/protocols/websocket/handlers/StatsHandler.hpp
+++ b/include/protocols/websocket/handlers/StatsHandler.hpp
@@ -10,7 +10,8 @@ class WebSocketSession;
 
 struct StatsHandler {
     static void handleVaultStats(const json& msg, WebSocketSession& session);
-    static void handleCacheStats(const json& msg, WebSocketSession& session);
+    static void handleFSCacheStats(const json& msg, WebSocketSession& session);
+    static void handleHttpCacheStats(const json& msg, WebSocketSession& session);
 };
 
 }

--- a/include/services/ServiceDepsRegistry.hpp
+++ b/include/services/ServiceDepsRegistry.hpp
@@ -21,6 +21,10 @@ namespace vh::shell {
     class UsageManager;
 }
 
+namespace vh::types {
+struct CacheStats;
+}
+
 namespace vh::services {
 
 class SyncController;
@@ -33,6 +37,7 @@ struct ServiceDepsRegistry {
     std::shared_ptr<storage::FSCache> fsCache;
     std::shared_ptr<shell::UsageManager> shellUsageManager;
     fuse_session* fuseSession = nullptr;
+    std::shared_ptr<types::CacheStats> httpCacheStats;
 
     void setFuseSession(fuse_session* fuseSession) { this->fuseSession = fuseSession; }
 

--- a/include/types/stats/CacheStats.hpp
+++ b/include/types/stats/CacheStats.hpp
@@ -85,10 +85,23 @@ struct CacheStats {
     static double max_op_ms(const CacheStatsSnapshot& s) noexcept;
 };
 
+struct ScopedOpTimer {
+    CacheStats* stats;
+    std::chrono::steady_clock::time_point start{};
+    explicit ScopedOpTimer(CacheStats* s)
+        : stats(s), start(std::chrono::steady_clock::now()) {}
+    ~ScopedOpTimer() {
+        const auto end = std::chrono::steady_clock::now();
+        stats->record_op_us(std::chrono::duration_cast<std::chrono::microseconds>(end - start).count());
+    }
+};
+
 // JSON serialization
 void to_json(nlohmann::json& j, const std::shared_ptr<CacheStatsSnapshot>& s);
+void to_json(nlohmann::json& j, const CacheStatsSnapshot& s);
 
 // Optional convenience (serializes snapshot + derived fields)
 void to_json(nlohmann::json& j, const std::shared_ptr<CacheStats>& s);
+void to_json(nlohmann::json& j, const CacheStats& s);
 
 } // namespace vh::types

--- a/src/database/Queries/UserQueries.cpp
+++ b/src/database/Queries/UserQueries.cpp
@@ -67,7 +67,7 @@ std::shared_ptr<User> UserQueries::getUserByLinuxUID(unsigned int linuxUid) {
     return Transactions::exec("UserQueries::getUserByLinuxUID", [&](pqxx::work& txn) -> std::shared_ptr<User> {
         const pqxx::result res = txn.exec(pqxx::prepped{"get_user_by_linux_uid"}, pqxx::params{linuxUid});
         if (res.empty()) {
-            LogRegistry::db()->error("[UserQueries] No user found with Linux UID: {}", linuxUid);
+            LogRegistry::db()->debug("[UserQueries] No user found with Linux UID: {}", linuxUid);
             return nullptr;
         }
         const auto userRow = res.one_row();

--- a/src/protocols/http/HttpRouter.cpp
+++ b/src/protocols/http/HttpRouter.cpp
@@ -14,8 +14,7 @@
 #include "types/FSEntry.hpp"
 #include "storage/FSCache.hpp"
 #include "types/stats/CacheStats.hpp"
-
-#include <ranges>
+#include "protocols/http/PreviewRequest.hpp"
 
 using namespace vh::services;
 using namespace vh::logging;
@@ -24,112 +23,128 @@ using namespace vh::types;
 
 namespace vh::http {
 
-HttpRouter::HttpRouter()
-    : authManager_(ServiceDepsRegistry::instance().authManager),
-      storageManager_(ServiceDepsRegistry::instance().storageManager),
-      imagePreviewHandler_(std::make_shared<ImagePreviewHandler>(storageManager_)),
-      pdfPreviewHandler_(std::make_shared<PdfPreviewHandler>(storageManager_)) {
-    if (!authManager_) throw std::invalid_argument("AuthManager cannot be null");
-    if (!storageManager_) throw std::invalid_argument("StorageManager cannot be null");
+static PreviewResponse noMimeType(const http::request<http::string_body>& req, const std::filesystem::path& path) {
+    LogRegistry::http()->error("[HttpRouter] File {} has no MIME type", path.string());
+    http::response<http::string_body> res{http::status::unsupported_media_type, req.version()};
+    res.set(http::field::content_type, "text/plain");
+    res.body() = "File has no MIME type";
+    res.prepare_payload();
+    return res;
 }
 
-PreviewResponse HttpRouter::route(http::request<http::string_body>&& req) const {
-    if (req.method() != http::verb::get || !req.target().starts_with("/preview")) {
-        http::response<http::string_body> res{http::status::bad_request, req.version()};
-        res.set(http::field::content_type, "text/plain");
-        res.body() = "Invalid request";
-        res.prepare_payload();
-        return res;
+static std::vector<uint8_t> tryCacheRead(const std::shared_ptr<File>& f, const std::filesystem::path& thumbnailRoot,
+                                         const unsigned int size) {
+    if (const auto thumbnail_sizes = ConfigRegistry::get().caching.thumbnails.sizes;
+        std::ranges::find(thumbnail_sizes.begin(), thumbnail_sizes.end(), size) != thumbnail_sizes.end()) {
+
+        if (const auto pathToJpegCache = thumbnailRoot / f->base32_alias / std::string(std::to_string(size) + ".jpg");
+            f->mime_type && (f->mime_type->starts_with("image/") || f->mime_type->starts_with("application/"))
+            && std::filesystem::exists(pathToJpegCache))
+            return util::readFileToVector(pathToJpegCache);
+
+        ServiceDepsRegistry::instance().httpCacheStats->record_miss();
     }
+    return {};
+}
 
-    if (!ConfigRegistry::get().dev.enabled) {
-        try {
-            const auto refresh_token = util::extractCookie(req, "refresh");
-            authManager_->validateRefreshToken(refresh_token);
-        } catch (const std::exception& e) {
-            http::response<http::string_body> res{http::status::unauthorized, req.version()};
-            res.set(http::field::content_type, "text/plain");
-            res.body() = "Unauthorized: " + std::string(e.what());
-            res.prepare_payload();
-            return res;
-        }
+std::string HttpRouter::authenticateRequest(const http::request<http::string_body>& req) {
+    if (ConfigRegistry::get().dev.enabled) return "";
+    try {
+        const auto refresh_token = util::extractCookie(req, "refresh");
+        ServiceDepsRegistry::instance().authManager->validateRefreshToken(refresh_token);
+        return "";
+    } catch (const std::exception& e) {
+        return e.what();
     }
+}
 
-    auto params = util::parse_query_params(req.target());
-    const auto vault_it = params.find("vault_id");
-    const auto path_it = params.find("path");
-    if (vault_it == params.end() || path_it == params.end()) {
-        http::response<http::string_body> res{http::status::bad_request, req.version()};
-        res.body() = "Missing vault_id or path";
-        res.prepare_payload();
-        return res;
-    }
+PreviewResponse HttpRouter::route(http::request<http::string_body>&& req) {
+    if (req.method() != http::verb::get || !req.target().starts_with("/preview"))
+        return makeErrorResponse(
+            req, "Invalid request", http::status::bad_request);
 
-    const auto vault_id = std::stoi(vault_it->second);
-    std::filesystem::path rel_path = path_it->second;
+    if (const auto error = authenticateRequest(req); !error.empty())
+        return makeErrorResponse(
+            req, "Unauthorized: " + error, http::status::unauthorized);
 
-    const auto size_it = params.find("size");
+    std::unique_ptr<PreviewRequest> pr;
+    try { pr = std::make_unique<PreviewRequest>(util::parse_query_params(req.target())); } catch (const std::exception&
+        e) { return makeErrorResponse(req, e.what(), http::status::bad_request); }
 
-    const auto engine = storageManager_->getEngine(vault_id);
-    if (!engine) throw std::runtime_error("No storage engine found for vault with ID: " + std::to_string(vault_id));
+    pr->engine = ServiceDepsRegistry::instance().storageManager->getEngine(pr->vault_id);
+    if (!pr->engine)
+        return makeErrorResponse(
+            req, "No storage engine found for vault with id " + std::to_string(pr->vault_id),
+            http::status::bad_request);
 
-    const auto fusePath = engine->paths->absRelToAbsRel(rel_path, PathType::VAULT_ROOT, PathType::FUSE_ROOT);
-
+    const auto fusePath = pr->engine->paths->absRelToAbsRel(pr->rel_path, PathType::VAULT_ROOT, PathType::FUSE_ROOT);
     const auto entry = ServiceDepsRegistry::instance().fsCache->getEntry(fusePath);
-    if (!entry) throw std::runtime_error("File not found in cache: " + fusePath.string());
-    if (entry->isDirectory()) throw std::runtime_error("Cannot generate preview for directory: " + fusePath.string());
-    const auto file = std::static_pointer_cast<File>(entry);
+    if (!entry) return makeErrorResponse(req, "File not found in cache");
+    if (entry->isDirectory())
+        return makeErrorResponse(req, "Requested preview file is a directory",
+                                 http::status::bad_request);
+    pr->file = std::static_pointer_cast<File>(entry);
 
-    if (!file->mime_type) {
-        LogRegistry::http()->error("[HttpRouter] File {} has no MIME type", rel_path.string());
-        http::response<http::string_body> res{http::status::unsupported_media_type, req.version()};
-        res.set(http::field::content_type, "text/plain");
-        res.body() = "File has no MIME type";
-        res.prepare_payload();
-        return res;
-    }
+    if (!pr->file->mime_type) return noMimeType(req, pr->rel_path);
 
-    if (size_it != params.end() && !size_it->second.empty()) {
-        const auto thumbnail_sizes = config::ConfigRegistry::get().caching.thumbnails.sizes;
-        const auto size = std::stoi(size_it->second);
-        if (std::ranges::find(thumbnail_sizes.begin(), thumbnail_sizes.end(), size) != thumbnail_sizes.end()) {
-            const auto filename = std::to_string(size) + ".jpg";
-            const auto pathToJpegCache = engine->paths->thumbnailRoot / file->base32_alias / filename;
-            if (file->mime_type && (file->mime_type->starts_with("image/") || file->mime_type->starts_with("application/"))) {
-                if (std::filesystem::exists(pathToJpegCache)) {
-                    const auto data = util::readFileToVector(pathToJpegCache);
+    if (pr->size)
+        if (auto data = tryCacheRead(pr->file, pr->engine->paths->thumbnailRoot, *pr->size); !data.empty())
+            return
+                makeResponse(req, std::move(data), *pr->file->mime_type, true);
 
-                    // Return decrypted image in memory
-                    http::response<http::string_body> res{
-                        http::status::ok, req.version()
-                    };
-                    res.set(http::field::content_type, "image/jpeg");
-                    res.body() = std::string(data.begin(), data.end());
-                    res.prepare_payload();
-                    res.keep_alive(req.keep_alive());
-                    ServiceDepsRegistry::instance().httpCacheStats->record_hit(data.size());
-                    return res;
-                }
-            }
-            ServiceDepsRegistry::instance().httpCacheStats->record_miss();
-        }
-    }
-
-    if (file->mime_type->starts_with("image/") || file->mime_type->ends_with("/pdf")) {
+    if (pr->file->mime_type->starts_with("image/") || pr->file->mime_type->ends_with("/pdf")) {
         ScopedOpTimer timer(ServiceDepsRegistry::instance().httpCacheStats.get());
-        PreviewResponse res;
-
-        if (file->mime_type->starts_with("image/")) res = imagePreviewHandler_->handle(std::move(req), vault_id, rel_path, params);
-        else res = pdfPreviewHandler_->handle(std::move(req), vault_id, rel_path, params);
-        return res;
+        return pr->file->mime_type->starts_with("image/")
+                   ? ImagePreviewHandler::handle(std::move(req), std::move(pr))
+                   : PdfPreviewHandler::handle(std::move(req), std::move(pr));
     }
 
-    return makeErrorResponse(req, "Unsupported preview type: " + (file->mime_type ? *file->mime_type : "unknown"));
+    return makeErrorResponse(
+        req, "Unsupported preview type: " + (pr->file->mime_type ? *pr->file->mime_type : "unknown"));
 }
 
-http::response<http::string_body> HttpRouter::makeErrorResponse(const http::request<http::string_body>& req,
-                                                                const std::string& msg) {
-    http::response<http::string_body> res{http::status::not_found, req.version()};
+PreviewResponse HttpRouter::makeResponse(const http::request<http::string_body>& req, std::vector<uint8_t>&& data,
+                                         const std::string& mime_type, const bool cacheHit) {
+    const auto size = data.size();
+
+    http::response<http::vector_body<uint8_t> > res{
+        std::piecewise_construct,
+        std::make_tuple(std::move(data)),
+        std::make_tuple(http::status::ok, req.version())
+    };
+
+    res.set(http::field::content_type, mime_type);
+    res.content_length(size);
+    res.keep_alive(req.keep_alive());
+
+    if (cacheHit) ServiceDepsRegistry::instance().httpCacheStats->record_hit(size);
+
+    return res;
+}
+
+PreviewResponse HttpRouter::makeResponse(const http::request<http::string_body>& req, http::file_body::value_type data,
+                                         const std::string& mime_type, const bool cacheHit) {
+    const auto size = data.size();
+
+    http::response<http::file_body> res{
+        std::piecewise_construct,
+        std::make_tuple(std::move(data)),
+        std::make_tuple(http::status::ok, req.version())
+    };
+
+    res.set(http::field::content_type, mime_type);
+    res.content_length(size);
+    res.keep_alive(req.keep_alive());
+
+    if (cacheHit) ServiceDepsRegistry::instance().httpCacheStats->record_hit(size);
+
+    return res;
+}
+
+PreviewResponse HttpRouter::makeErrorResponse(const http::request<http::string_body>& req,
+                                              const std::string& msg,
+                                              const http::status& status) {
+    http::response<http::string_body> res{status, req.version()};
     res.set(http::field::content_type, "text/plain");
     res.body() = msg;
     res.prepare_payload();

--- a/src/protocols/http/HttpServer.cpp
+++ b/src/protocols/http/HttpServer.cpp
@@ -1,7 +1,5 @@
 #include "protocols/http/HttpServer.hpp"
 #include "protocols/http/HttpSession.hpp"
-#include "protocols/http/HttpRouter.hpp"
-#include "services/ServiceManager.hpp"
 #include "protocols/http/HttpSessionTask.hpp"
 #include "concurrency/ThreadPool.hpp"
 #include "concurrency/ThreadPoolManager.hpp"
@@ -16,7 +14,6 @@ namespace vh::http {
 
 HttpServer::HttpServer(net::io_context& ioc, const tcp::endpoint& endpoint)
     : acceptor_(ioc), socket_(ioc),
-      router_(std::make_shared<HttpRouter>()),
       authManager_(ServiceDepsRegistry::instance().authManager),
       storageManager_(ServiceDepsRegistry::instance().storageManager) {
     beast::error_code ec;
@@ -40,7 +37,7 @@ void HttpServer::run() {
 void HttpServer::do_accept() {
     acceptor_.async_accept(socket_, [self = shared_from_this()](beast::error_code ec) mutable {
         if (!ec) {
-            auto session = std::make_shared<HttpSession>(std::move(self->socket_), self->router_);
+            auto session = std::make_shared<HttpSession>(std::move(self->socket_));
             ThreadPoolManager::instance().httpPool()->submit(std::make_unique<HttpSessionTask>(std::move(session)));
         }
         self->do_accept();

--- a/src/protocols/http/HttpSession.cpp
+++ b/src/protocols/http/HttpSession.cpp
@@ -9,10 +9,8 @@ using namespace vh::logging;
 
 namespace vh::http {
 
-HttpSession::HttpSession(tcp::socket socket,
-                         std::shared_ptr<HttpRouter> router)
+HttpSession::HttpSession(tcp::socket socket)
     : socket_(std::move(socket)),
-      router_(std::move(router)),
       auth_(ServiceDepsRegistry::instance().authManager),
       storage_(ServiceDepsRegistry::instance().storageManager) {
     if (!auth_) throw std::invalid_argument("AuthManager cannot be null");
@@ -46,7 +44,7 @@ void HttpSession::on_read(beast::error_code ec, std::size_t bytes) {
     auto self = shared_from_this();
 
     try {
-        auto res = router_->route(std::move(req_));
+        auto res = HttpRouter::route(std::move(req_));
 
         std::visit([self](auto&& response) {
             using T = std::decay_t<decltype(response)>;

--- a/src/protocols/http/handlers/ImagePreviewHandler.cpp
+++ b/src/protocols/http/handlers/ImagePreviewHandler.cpp
@@ -4,6 +4,8 @@
 #include "database/Queries/FileQueries.hpp"
 #include "storage/StorageManager.hpp"
 #include "logging/LogRegistry.hpp"
+#include "protocols/http/PreviewRequest.hpp"
+#include "protocols/http/HttpRouter.hpp"
 
 #include <boost/beast/http/file_body.hpp>
 
@@ -14,62 +16,24 @@ using namespace vh::database;
 
 namespace vh::http {
 
-PreviewResponse ImagePreviewHandler::handle(http::request<http::string_body>&& req, int vault_id, const std::string& rel_path,
-                                                    const std::unordered_map<std::string, std::string>& params) const {
+PreviewResponse ImagePreviewHandler::handle(http::request<http::string_body>&& req, const std::unique_ptr<PreviewRequest>&& pr) {
     try {
-        const auto scale_it = params.find("scale");
-        const auto size_it = params.find("size");
+        const auto tmpPath = decrypt_file_to_temp(pr->vault_id, pr->rel_path, pr->engine);
 
-        const auto engine = storageManager_->getEngine(vault_id);
-        const auto tmpPath = decrypt_file_to_temp(vault_id, rel_path, engine);
-
-        std::string mime_type = FileQueries::getMimeType(vault_id, {rel_path});
-
-        if (scale_it != params.end() || size_it != params.end()) {
-            std::optional<std::string> scale, size;
-            if (scale_it != params.end()) scale = scale_it->second;
-            if (size_it != params.end()) size = size_it->second;
-
-            std::vector<uint8_t> resized = resize_and_compress_image(tmpPath, scale, size);
-
-            http::response<http::vector_body<uint8_t>> res{http::status::ok, req.version()};
-            res.set(http::field::content_type, mime_type);
-            res.body() = std::move(resized);
-            res.content_length(res.body().size());
-            res.keep_alive(req.keep_alive());
-            res.prepare_payload();
-            return res;
+        if (pr->size || pr->scale) {
+            std::vector<uint8_t> resized = resize_and_compress_image(tmpPath, pr->scaleStr(), pr->sizeStr());
+            return HttpRouter::makeResponse(req, std::move(resized), "image/jpeg");
         }
 
         boost::beast::error_code ec;
         http::file_body::value_type body;
         body.open(tmpPath.c_str(), boost::beast::file_mode::scan, ec);
-        if (ec) {
-            LogRegistry::http()->error("[ImagePreviewHandler::handle] Error opening temporary file");
-            http::response<http::string_body> res{http::status::not_found, req.version()};
-            res.set(http::field::content_type, "text/plain");
-            res.body() = "File not found";
-            res.prepare_payload();
-            return res;
-        }
+        if (ec) return HttpRouter::makeErrorResponse(req, "File not found.", http::status::not_found);
 
-        uintmax_t file_size = body.size();
-        http::response<http::file_body> res{
-            std::piecewise_construct,
-            std::make_tuple(std::move(body)),
-            std::make_tuple(http::status::ok, req.version())
-        };
-        res.set(http::field::content_type, mime_type);
-        res.content_length(file_size);
-        res.keep_alive(req.keep_alive());
-        return res;
+        return HttpRouter::makeResponse(req, std::move(body), "image/jpeg");
     } catch (const std::exception& e) {
-        LogRegistry::http()->error("[ImagePreviewHandler] Error handling image preview for {}: {}", rel_path, e.what());
-        http::response<http::string_body> err{http::status::unsupported_media_type, req.version()};
-        err.set(http::field::content_type, "text/plain");
-        err.body() = "Failed to load image: " + std::string(e.what());
-        err.prepare_payload();
-        return err;
+        LogRegistry::http()->error("[ImagePreviewHandler] Error handling image preview for {}: {}", pr->rel_path.string(), e.what());
+        return HttpRouter::makeErrorResponse(req, "Failed to load image: " + std::string(e.what()), http::status::unsupported_media_type);
     }
 }
 

--- a/src/protocols/http/handlers/ImagePreviewHandler.cpp
+++ b/src/protocols/http/handlers/ImagePreviewHandler.cpp
@@ -45,6 +45,7 @@ PreviewResponse ImagePreviewHandler::handle(http::request<http::string_body>&& r
         http::file_body::value_type body;
         body.open(tmpPath.c_str(), boost::beast::file_mode::scan, ec);
         if (ec) {
+            LogRegistry::http()->error("[ImagePreviewHandler::handle] Error opening temporary file");
             http::response<http::string_body> res{http::status::not_found, req.version()};
             res.set(http::field::content_type, "text/plain");
             res.body() = "File not found";
@@ -52,13 +53,14 @@ PreviewResponse ImagePreviewHandler::handle(http::request<http::string_body>&& r
             return res;
         }
 
+        uintmax_t file_size = body.size();
         http::response<http::file_body> res{
             std::piecewise_construct,
             std::make_tuple(std::move(body)),
             std::make_tuple(http::status::ok, req.version())
         };
         res.set(http::field::content_type, mime_type);
-        res.content_length(body.size());
+        res.content_length(file_size);
         res.keep_alive(req.keep_alive());
         return res;
     } catch (const std::exception& e) {

--- a/src/protocols/websocket/WebSocketHandler.cpp
+++ b/src/protocols/websocket/WebSocketHandler.cpp
@@ -251,8 +251,12 @@ void WebSocketHandler::registerStatHandlers() const {
         StatsHandler::handleVaultStats(msg, session);
     });
 
-    router_->registerHandler("stats.cache", [this](const json& msg, WebSocketSession& session) {
-        StatsHandler::handleCacheStats(msg, session);
+    router_->registerHandler("stats.fs.cache", [this](const json& msg, WebSocketSession& session) {
+        StatsHandler::handleFSCacheStats(msg, session);
+    });
+
+    router_->registerHandler("stats.http.cache", [this](const json& msg, WebSocketSession& session) {
+        StatsHandler::handleHttpCacheStats(msg, session);
     });
 }
 

--- a/src/services/ServiceDepsRegistry.cpp
+++ b/src/services/ServiceDepsRegistry.cpp
@@ -5,6 +5,7 @@
 #include "storage/FSCache.hpp"
 #include "crypto/APIKeyManager.hpp"
 #include "logging/LogRegistry.hpp"
+#include "types/stats/CacheStats.hpp"
 #include "usage/include/UsageManager.hpp"
 
 using namespace vh::services;
@@ -12,6 +13,7 @@ using namespace vh::storage;
 using namespace vh::crypto;
 using namespace vh::auth;
 using namespace vh::logging;
+using namespace vh::types;
 
 ServiceDepsRegistry& ServiceDepsRegistry::instance() {
     static ServiceDepsRegistry instance_;
@@ -34,6 +36,7 @@ void ServiceDepsRegistry::init() {
     ctx.authManager = std::make_shared<AuthManager>();
     ctx.fsCache = std::make_shared<FSCache>();
     ctx.shellUsageManager = std::make_shared<shell::UsageManager>();
+    ctx.httpCacheStats = std::make_shared<CacheStats>();
 
     LogRegistry::vaulthalla()->info("[ServiceDepsRegistry] Initialized.");
 }

--- a/src/storage/FSCache.cpp
+++ b/src/storage/FSCache.cpp
@@ -115,7 +115,7 @@ std::shared_ptr<FSEntry> FSCache::getEntry(const fs::path& absPath) {
         const auto ino = getOrAssignInode(path);
         auto entry = FSEntryQueries::getFSEntryByInode(ino);
         if (!entry) {
-            LogRegistry::storage()->warn("[FSCache] No entry found for path: {}", path.string());
+            LogRegistry::storage()->debug("[FSCache] No entry found for path: {}", path.string());
             return nullptr;
         }
 
@@ -364,7 +364,7 @@ void FSCache::evictIno(fuse_ino_t ino) {
     std::unique_lock lock(mutex_);
 
     if (!inodeToPath_.contains(ino) || !inodeToId_.contains(ino)) {
-        LogRegistry::fs()->warn("[FSCache] Attempted to destroy references for non-existent inode: {}", ino);
+        LogRegistry::fs()->debug("[FSCache] Attempted to destroy references for non-existent inode: {}", ino);
         return;
     }
 
@@ -400,7 +400,7 @@ void FSCache::evictPath(const fs::path& path) {
     {
         std::unique_lock lock(mutex_);
         if (!pathToInode_.contains(path)) {
-            LogRegistry::fs()->warn("[FSCache] Attempted to evict non-existent path: {}", path.string());
+            LogRegistry::fs()->debug("[FSCache] Attempted to evict non-existent path: {}", path.string());
             return;
         }
         ino = pathToInode_[path];

--- a/src/storage/FUSEBridge.cpp
+++ b/src/storage/FUSEBridge.cpp
@@ -227,7 +227,7 @@ void lookup(const fuse_req_t req, const fuse_ino_t parent, const char* name) {
     
     const auto user = UserQueries::getUserByLinuxUID(uid);
     if (!user) {
-        LogRegistry::fuse()->error("[lookup] No user found for UID: {}", uid);
+        LogRegistry::fuse()->debug("[lookup] No user found for UID: {}", uid);
         fuse_reply_err(req, EACCES);
         return;
     }
@@ -242,7 +242,7 @@ void lookup(const fuse_req_t req, const fuse_ino_t parent, const char* name) {
 
     const auto entry = cache->getEntry(path);
     if (!entry) {
-        LogRegistry::fuse()->error("[lookup] Entry not found for path: {}", path.string());
+        LogRegistry::fuse()->debug("[lookup] Entry not found for path: {}", path.string());
         fuse_reply_err(req, ENOENT);
         return;
     }

--- a/src/types/stats/CacheStats.cpp
+++ b/src/types/stats/CacheStats.cpp
@@ -89,31 +89,37 @@ double CacheStats::max_op_ms(const CacheStatsSnapshot& s) noexcept {
 }
 
 // Snapshot serialization (best practice)
-void vh::types::to_json(nlohmann::json& j, const std::shared_ptr<CacheStatsSnapshot>& s) {
+void vh::types::to_json(nlohmann::json& j, const CacheStatsSnapshot& s) {
     j = nlohmann::json{
-        {"hits", s->hits},
-        {"misses", s->misses},
-        {"evictions", s->evictions},
-        {"inserts", s->inserts},
-        {"invalidations", s->invalidations},
+        {"hits", s.hits},
+        {"misses", s.misses},
+        {"evictions", s.evictions},
+        {"inserts", s.inserts},
+        {"invalidations", s.invalidations},
 
-        {"bytes_read", s->bytes_read},
-        {"bytes_written", s->bytes_written},
+        {"bytes_read", s.bytes_read},
+        {"bytes_written", s.bytes_written},
 
-        {"used_bytes", s->used_bytes},
-        {"capacity_bytes", s->capacity_bytes},
+        {"used_bytes", s.used_bytes},
+        {"capacity_bytes", s.capacity_bytes},
 
         {"op", {
-            {"count", s->op_count},
-            {"total_us", s->op_total_us},
-            {"max_us", s->op_max_us},
+            {"count", s.op_count},
+            {"total_us", s.op_total_us},
+            {"max_us", s.op_max_us},
+            {"avg_ms", CacheStats::avg_op_ms(s)},
+            {"max_ms", CacheStats::max_op_ms(s)},
         }},
     };
 }
 
+void vh::types::to_json(nlohmann::json& j, const std::shared_ptr<CacheStatsSnapshot>& s) {
+    j = *s;
+}
+
 // Convenience serialization (snapshot + derived fields)
-void vh::types::to_json(nlohmann::json& j, const std::shared_ptr<CacheStats>& s) {
-    const auto snap = s->snapshot();
+void vh::types::to_json(nlohmann::json& j, const CacheStats& s) {
+    const auto snap = s.snapshot();
 
     j = nlohmann::json{
         {"hits", snap.hits},
@@ -139,4 +145,8 @@ void vh::types::to_json(nlohmann::json& j, const std::shared_ptr<CacheStats>& s)
             {"max_ms", CacheStats::max_op_ms(snap)},
         }},
     };
+}
+
+void vh::types::to_json(nlohmann::json& j, const std::shared_ptr<CacheStats>& s) {
+    j = *s;
 }

--- a/tests/integrations/include/CLITestConfig.hpp
+++ b/tests/integrations/include/CLITestConfig.hpp
@@ -21,6 +21,16 @@ struct CLITestConfig {
         };
     }
 
+    static CLITestConfig Medium() {
+        return CLITestConfig{
+            .numUsers = 15,
+            .numVaults = 20,
+            .numGroups = 10,
+            .numUserRoles = 10,
+            .numVaultRoles = 10
+        };
+    }
+
     static CLITestConfig Large() {
         return CLITestConfig{
             .numUsers = 50,


### PR DESCRIPTION
adds valuable stats for hits/misses, operations avg/max time on miss, etc. Also cleans up much of the code supporting the Http end of things with a full refactor of routing on the preview server.