### PR TITLE
Refactor FUSE layer: introduce Resolver pipeline, eliminate exceptions, and reduce Bridge complexity

### DIFF
--- a/include/db/query/identities/Group.hpp
+++ b/include/db/query/identities/Group.hpp
@@ -30,6 +30,7 @@ public:
     static GroupPtr getGroupByName(const std::string& name);
     static std::vector<GroupPtr> listGroups(const std::optional<uint32_t>& userId = {}, model::ListQueryParams&& params = {});
     [[nodiscard]] static bool groupExists(const std::string& name);
+    static GroupPtr getGroupByLinuxGID(uint32_t gid);
 };
 
 }

--- a/include/db/query/identities/helpers.hpp
+++ b/include/db/query/identities/helpers.hpp
@@ -23,7 +23,7 @@ namespace vh {
         void upsertVaultRoles(pqxx::work& txn, const std::unordered_map<uint32_t, std::shared_ptr<vh::rbac::role::Vault>>& vRoles,
                                      const std::string &subjectType, uint32_t subjectId);
 
-        void upsertGlobalVRoles(pqxx::work& txn, const rbac::permission::admin::VaultGlobals &vGlobal, uint32_t userId);
+        void upsertGlobalVRoles(pqxx::work& txn, const vh::rbac::permission::admin::VaultGlobals &vGlobal, uint32_t userId);
 
         void upsertAdminRoleAssignment(pqxx::work& txn, uint32_t userId, uint32_t roleId);
 

--- a/include/db/query/identities/helpers.hpp
+++ b/include/db/query/identities/helpers.hpp
@@ -20,14 +20,14 @@ namespace vh {
 
         void upsertUserRoles(pqxx::work& txn, const std::shared_ptr<vh::identities::User>& user);
 
-        void upsertVaultRoles(pqxx::work& txn, const std::unordered_map<uint32_t, std::shared_ptr<rbac::role::Vault>>& vRoles,
+        void upsertVaultRoles(pqxx::work& txn, const std::unordered_map<uint32_t, std::shared_ptr<vh::rbac::role::Vault>>& vRoles,
                                      const std::string &subjectType, uint32_t subjectId);
 
         void upsertGlobalVRoles(pqxx::work& txn, const rbac::permission::admin::VaultGlobals &vGlobal, uint32_t userId);
 
         void upsertAdminRoleAssignment(pqxx::work& txn, uint32_t userId, uint32_t roleId);
 
-        std::unordered_map<uint32_t, std::shared_ptr<rbac::role::Vault>> getVaultRoles(pqxx::work &txn, const std::string& subjectType, uint32_t subjectId);
+        std::unordered_map<uint32_t, std::shared_ptr<vh::rbac::role::Vault>> getVaultRoles(pqxx::work &txn, const std::string& subjectType, uint32_t subjectId);
 
         std::vector<std::shared_ptr<vh::identities::Group>> getUserGroups(pqxx::work& txn, uint32_t userId);
     }

--- a/include/fs/Filesystem.hpp
+++ b/include/fs/Filesystem.hpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <optional>
 #include <vector>
+#include <utility>
 #include <pqxx/pqxx>
 
 namespace vh::storage {
@@ -41,15 +42,16 @@ class Filesystem {
 public:
     static void init(const std::shared_ptr<storage::Manager>& manager);
     static bool isReady();
-    static void mkdir(const std::filesystem::path& absPath, mode_t mode = 0755, const std::optional<unsigned int>& userId = std::nullopt, std::shared_ptr<storage::Engine> engine = nullptr);
     static void mkVault(const std::filesystem::path& absPath, unsigned int vaultId, mode_t mode = 0755);
     static bool exists(const std::filesystem::path& absPath);
 
-    static void copy(const std::filesystem::path& from, const std::filesystem::path& to, unsigned int userId, std::shared_ptr<storage::Engine> engine = nullptr);
-    static void remove(const std::filesystem::path& path, unsigned int userId);
-    static void rename(const std::filesystem::path& oldPath, const std::filesystem::path& newPath, const std::optional<unsigned int>& userId = std::nullopt, std::shared_ptr<storage::Engine> engine = nullptr);
+    static int mkdir(const std::filesystem::path& absPath, mode_t mode = 0755, const std::optional<unsigned int>& userId = std::nullopt, std::shared_ptr<storage::Engine> engine = nullptr);
 
-    static std::shared_ptr<model::Entry> createFile(const std::filesystem::path& path, uid_t uid, gid_t gid, mode_t mode = 0644);
+    static int copy(const std::filesystem::path& from, const std::filesystem::path& to, unsigned int userId, std::shared_ptr<storage::Engine> engine = nullptr);
+    static void remove(const std::filesystem::path& path, unsigned int userId);
+    static int rename(const std::filesystem::path& oldPath, const std::filesystem::path& newPath, const std::optional<unsigned int>& userId = std::nullopt, std::shared_ptr<storage::Engine> engine = nullptr);
+
+    static std::pair<int, std::shared_ptr<model::Entry>> createFile(const std::filesystem::path& path, uid_t uid, gid_t gid, mode_t mode = 0644);
     static std::shared_ptr<model::File> createFile(const NewFileContext& ctx);
 
     static bool isPreviewable(const std::string& mimeType);
@@ -58,7 +60,7 @@ private:
     inline static std::mutex mutex_;
     inline static std::shared_ptr<storage::Manager> storageManager_ = nullptr;
 
-    static void handleRename(const RenameContext& ctx);
+    static int handleRename(const RenameContext& ctx);
 
     static bool canFastPath(const std::shared_ptr<model::Entry>& entry, const std::shared_ptr<storage::Engine>& engine);
 };

--- a/include/fuse/Reply.hpp
+++ b/include/fuse/Reply.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#define FUSE_USE_VERSION 35
+
+#include "resolver/Resolved.hpp"
+
+#include <fuse_lowlevel.h>
+#include <sys/stat.h>
+#include <string_view>
+
+namespace vh::fuse {
+    struct Reply {
+        static int err(fuse_req_t req, int errnum);
+
+        static bool failIfNotOk(
+            fuse_req_t req,
+            std::string_view caller,
+            const resolver::Resolved& resolved
+        );
+
+        static int entry(fuse_req_t req, const fuse_entry_param& entry);
+        static int attr(fuse_req_t req, const struct stat& stbuf, double timeout);
+        static int open(fuse_req_t req, fuse_file_info& fi);
+        static int buf(fuse_req_t req, const char* data, size_t size);
+        static int write(fuse_req_t req, size_t bytes);
+        static int none(fuse_req_t req);
+
+        static int invalid(fuse_req_t req);
+        static int access(fuse_req_t req);
+        static int noent(fuse_req_t req);
+        static int io(fuse_req_t req);
+    };
+}

--- a/include/fuse/Resolver.hpp
+++ b/include/fuse/Resolver.hpp
@@ -13,8 +13,9 @@ namespace vh::fuse {
         static bool resolveIdentity(const resolver::Request& req, resolver::Resolved& out);
         static bool resolveEntry(const resolver::Request& req, resolver::Resolved& out);
         static bool resolveParentEntry(const resolver::Request& req, resolver::Resolved& out);
-        static bool resolvePath(const resolver::Request& req, resolver::Resolved& out);
         static bool resolveEngine(const resolver::Request& req, resolver::Resolved& out);
+        static bool resolvePath(const resolver::Request& req, resolver::Resolved& out);
+        static bool resolveEntryForPath(const resolver::Request& req, resolver::Resolved& out);
         static bool enforcePermissions(const resolver::Request& req, resolver::Resolved& out);
     };
 }

--- a/include/fuse/Resolver.hpp
+++ b/include/fuse/Resolver.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#define FUSE_USE_VERSION 35
+
+#include "resolver/Resolved.hpp"
+#include "resolver/Request.hpp"
+
+namespace vh::fuse {
+    struct Resolver {
+        static resolver::Resolved resolve(const resolver::Request& req);
+
+    private:
+        static bool resolveIdentity(const resolver::Request& req, resolver::Resolved& out);
+        static bool resolveEntry(const resolver::Request& req, resolver::Resolved& out);
+        static bool resolveParentEntry(const resolver::Request& req, resolver::Resolved& out);
+        static bool resolvePath(const resolver::Request& req, resolver::Resolved& out);
+        static bool resolveEngine(const resolver::Request& req, resolver::Resolved& out);
+        static bool enforcePermissions(const resolver::Request& req, resolver::Resolved& out);
+    };
+}

--- a/include/fuse/Resolver.hpp
+++ b/include/fuse/Resolver.hpp
@@ -12,7 +12,6 @@ namespace vh::fuse {
     private:
         static bool resolveIdentity(const resolver::Request& req, resolver::Resolved& out);
         static bool resolveEntry(const resolver::Request& req, resolver::Resolved& out);
-        static bool resolveParentEntry(const resolver::Request& req, resolver::Resolved& out);
         static bool resolveEngine(const resolver::Request& req, resolver::Resolved& out);
         static bool resolvePath(const resolver::Request& req, resolver::Resolved& out);
         static bool resolveEntryForPath(const resolver::Request& req, resolver::Resolved& out);

--- a/include/fuse/resolver/Request.hpp
+++ b/include/fuse/resolver/Request.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#define FUSE_USE_VERSION 35
+
+#include "rbac/permission/vault/Filesystem.hpp"
+
+#include <fuse_lowlevel.h>
+#include <optional>
+#include <string>
+#include <cstdint>
+#include <vector>
+
+namespace vh::fuse::resolver {
+    enum class Target : uint32_t {
+        None = 0,
+        Entry = 1 << 0,
+        Path = 1 << 1,
+        EntryForPath = 1 << 2,
+    };
+
+    inline constexpr Target operator|(const Target lhs, const Target rhs) {
+        return static_cast<Target>(
+            static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs)
+        );
+    }
+
+    inline constexpr Target operator&(const Target lhs, const Target rhs) {
+        return static_cast<Target>(
+            static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs)
+        );
+    }
+
+    inline constexpr bool hasFlag(const Target value, const Target flag) {
+        return (static_cast<uint32_t>(value) & static_cast<uint32_t>(flag)) != 0;
+    }
+
+    struct Request {
+        std::string caller;
+        fuse_req_t fuseReq {};
+
+        std::optional<fuse_ino_t> ino, parentIno;
+        std::optional<std::string> childName;
+
+        std::optional<rbac::permission::vault::FilesystemAction> action;
+        std::vector<rbac::permission::vault::FilesystemAction> actions;
+
+        Target target {Target::Entry};
+    };
+}

--- a/include/fuse/resolver/Request.hpp
+++ b/include/fuse/resolver/Request.hpp
@@ -36,13 +36,13 @@ namespace vh::fuse::resolver {
 
     struct Request {
         std::string caller;
-        fuse_req_t fuseReq {};
+        fuse_req_t fuseReq;
 
-        std::optional<fuse_ino_t> ino, parentIno;
-        std::optional<std::string> childName;
+        std::optional<fuse_ino_t> ino{}, parentIno{};
+        std::optional<std::string> childName{};
 
-        std::optional<rbac::permission::vault::FilesystemAction> action;
-        std::vector<rbac::permission::vault::FilesystemAction> actions;
+        std::optional<rbac::permission::vault::FilesystemAction> action{};
+        std::vector<rbac::permission::vault::FilesystemAction> actions{};
 
         Target target {Target::Entry};
     };

--- a/include/fuse/resolver/Resolved.hpp
+++ b/include/fuse/resolver/Resolved.hpp
@@ -33,12 +33,12 @@ namespace vh {
             Status status {Status::Ok};
             int errnum {0};
 
-            std::shared_ptr<identities::User> user;
-            std::shared_ptr<identities::Group> group;
-            std::shared_ptr<fs::model::Entry> entry, parentEntry;
-            std::optional<std::filesystem::path> path, fusePath;
-            std::optional<fuse_ino_t> ino;
-            std::shared_ptr<storage::Engine> engine;
+            std::shared_ptr<identities::User> user{};
+            std::shared_ptr<identities::Group> group{};
+            std::shared_ptr<fs::model::Entry> entry{}, parentEntry{};
+            std::optional<std::filesystem::path> path{};
+            std::optional<fuse_ino_t> ino{};
+            std::shared_ptr<storage::Engine> engine{};
 
             [[nodiscard]] bool ok() const {
                 return status == Status::Ok;

--- a/include/fuse/resolver/Resolved.hpp
+++ b/include/fuse/resolver/Resolved.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <filesystem>
+#include <fuse_lowlevel.h>
+#include <memory>
+#include <optional>
+
+namespace vh {
+    namespace identities { struct User; struct Group; }
+    namespace fs::model { struct Entry; }
+    namespace storage { struct Engine; }
+
+    namespace fuse::resolver {
+        enum class Status {
+            Ok,
+            MissingFuseContext,
+            MissingIno,
+            MissingChildName,
+            MissingParentPath,
+            MissingUser,
+            MissingEntry,
+            MissingParentIno,
+            MissingParentEntry,
+            MissingPath,
+            MissingEngine,
+            InvalidChildPath,
+            AccessDenied,
+            InvalidRequest,
+            InternalError
+        };
+
+        struct Resolved {
+            Status status {Status::Ok};
+            int errnum {0};
+
+            std::shared_ptr<identities::User> user;
+            std::shared_ptr<identities::Group> group;
+            std::shared_ptr<fs::model::Entry> entry, parentEntry;
+            std::optional<std::filesystem::path> path, fusePath;
+            std::optional<fuse_ino_t> ino;
+            std::shared_ptr<storage::Engine> engine;
+
+            [[nodiscard]] bool ok() const {
+                return status == Status::Ok;
+            }
+
+            void setStatus(const Status& status, const int errnum) {
+                this->status = status;
+                this->errnum = errnum;
+            }
+        };
+    }
+}

--- a/include/fuse/resolver/Resolved.hpp
+++ b/include/fuse/resolver/Resolved.hpp
@@ -35,8 +35,8 @@ namespace vh {
 
             std::shared_ptr<identities::User> user{};
             std::shared_ptr<identities::Group> group{};
-            std::shared_ptr<fs::model::Entry> entry{}, parentEntry{};
-            std::optional<std::filesystem::path> path{};
+            std::shared_ptr<fs::model::Entry> entry{};
+            std::optional<std::filesystem::path> path{}, vaultPath{};
             std::optional<fuse_ino_t> ino{};
             std::shared_ptr<storage::Engine> engine{};
 

--- a/include/fuse/task/Request.hpp
+++ b/include/fuse/task/Request.hpp
@@ -9,7 +9,15 @@ class Request final : public concurrency::Task {
 public:
     Request(fuse_session* session, const fuse_buf& buf) : session_(session), buf_(buf) {}
 
-    void operator()() override { fuse_session_process_buf(session_, &buf_); }
+    void operator()() override {
+        try {
+            fuse_session_process_buf(session_, &buf_);
+        } catch (const std::exception& ex) {
+            log::Registry::fuse()->critical("[fuse::task::Request] Unhandled exception: {}", ex.what());
+        } catch (...) {
+            log::Registry::fuse()->critical("[fuse::task::Request] Unhandled unknown exception");
+        }
+    }
 
 private:
     fuse_session* session_;

--- a/include/rbac/resolver/Vault.hpp
+++ b/include/rbac/resolver/Vault.hpp
@@ -185,16 +185,6 @@ namespace vh::rbac::resolver {
         template<typename EnumT>
         static bool has(vault::Context<EnumT> &&ctx) {
             if (!ctx.isValid()) return false;
-
-            log::Registry::auth()->warn(
-    "user bypass check: isSuperAdmin={}, name='{}', size={}, id={}, role_name={}",
-    ctx.user->isSuperAdmin(),
-    ctx.user->name,
-    ctx.user->name.size(),
-    ctx.user->id,
-    ctx.user->roles.admin->name
-);
-
             if (ctx.user->isSuperAdmin()) return true;
 
             const auto resolved = resolveVaultContext(

--- a/src/db/preparedStatements/identities/groups.cpp
+++ b/src/db/preparedStatements/identities/groups.cpp
@@ -193,4 +193,6 @@ void vh::db::DBConnection::initPreparedGroups() const {
             ) AS exists
         )SQL"
     );
+
+    conn_->prepare("get_group_by_linux_gid", "SELECT * FROM groups WHERE linux_gid = $1");
 }

--- a/src/db/query/auth/RefreshToken.cpp
+++ b/src/db/query/auth/RefreshToken.cpp
@@ -8,106 +8,106 @@
 
 #include <chrono>
 
-using namespace vh::db::query::auth;
+namespace vh::db::query::auth {
+    void RefreshToken::set(const std::shared_ptr<vh::auth::model::RefreshToken>& token) {
+        if (!token) {
+            log::Registry::db()->error("[RefreshToken] Attempted to set a null refresh token");
+            return;
+        }
 
-void RefreshToken::set(const std::shared_ptr<vh::auth::model::RefreshToken>& token) {
-    if (!token) {
-        log::Registry::db()->error("[RefreshToken] Attempted to set a null refresh token");
-        return;
+        Transactions::exec("RefreshToken::setRefreshToken", [&](pqxx::work& txn) {
+            const pqxx::params p{
+                token->jti,
+                token->userId,
+                token->hashedToken,
+                token->ipAddress,
+                token->userAgent,
+                encoding::timestampToString(std::chrono::system_clock::to_time_t(token->issuedAt)),
+                encoding::timestampToString(std::chrono::system_clock::to_time_t(token->expiresAt)),
+            };
+
+            txn.exec(pqxx::prepped{"insert_refresh_token"}, p);
+        });
     }
 
-    Transactions::exec("RefreshToken::setRefreshToken", [&](pqxx::work& txn) {
-        const pqxx::params p{
-            token->jti,
-            token->userId,
-            token->hashedToken,
-            token->ipAddress,
-            token->userAgent,
-            encoding::timestampToString(std::chrono::system_clock::to_time_t(token->issuedAt)),
-            encoding::timestampToString(std::chrono::system_clock::to_time_t(token->expiresAt)),
-        };
-
-        txn.exec(pqxx::prepped{"insert_refresh_token"}, p);
-    });
-}
-
-void RefreshToken::remove(const std::string& jti) {
-    Transactions::exec("RefreshToken::removeRefreshToken", [&](pqxx::work& txn) {
-        txn.exec(pqxx::prepped{"delete_refresh_token_by_jti"}, pqxx::params{jti});
-    });
-}
-
-std::shared_ptr<vh::auth::model::RefreshToken> RefreshToken::get(const std::string& jti) {
-    return Transactions::exec(
-        "RefreshToken::getRefreshToken",
-        [&](pqxx::work& txn) -> std::shared_ptr<vh::auth::model::RefreshToken> {
-            const auto res = txn.exec(pqxx::prepped{"get_refresh_token_by_jti"}, pqxx::params{jti});
-
-            if (res.empty()) {
-                log::Registry::db()->trace("[RefreshToken] No refresh token found for JTI: {}", jti);
-                return nullptr;
-            }
-
-            return std::make_shared<vh::auth::model::RefreshToken>(res.one_row());
+    void RefreshToken::remove(const std::string& jti) {
+        Transactions::exec("RefreshToken::removeRefreshToken", [&](pqxx::work& txn) {
+            txn.exec(pqxx::prepped{"delete_refresh_token_by_jti"}, pqxx::params{jti});
         });
-}
+    }
 
-std::vector<std::shared_ptr<vh::auth::model::RefreshToken>> RefreshToken::list(const unsigned int userId) {
-    return Transactions::exec("RefreshToken::listRefreshTokens", [&](pqxx::work& txn) {
-        const auto res = txn.exec(pqxx::prepped{"list_active_refresh_tokens_for_user"}, pqxx::params{userId});
+    std::shared_ptr<vh::auth::model::RefreshToken> RefreshToken::get(const std::string& jti) {
+        return Transactions::exec(
+            "RefreshToken::getRefreshToken",
+            [&](pqxx::work& txn) -> std::shared_ptr<vh::auth::model::RefreshToken> {
+                const auto res = txn.exec(pqxx::prepped{"get_refresh_token_by_jti"}, pqxx::params{jti});
 
-        std::vector<std::shared_ptr<vh::auth::model::RefreshToken>> tokens;
-        tokens.reserve(res.size());
+                if (res.empty()) {
+                    log::Registry::db()->trace("[RefreshToken] No refresh token found for JTI: {}", jti);
+                    return nullptr;
+                }
 
-        for (const auto& row : res)
-            tokens.push_back(std::make_shared<vh::auth::model::RefreshToken>(row));
+                return std::make_shared<vh::auth::model::RefreshToken>(res.one_row());
+            });
+    }
 
-        return tokens;
-    });
-}
+    std::vector<std::shared_ptr<vh::auth::model::RefreshToken>> RefreshToken::list(const unsigned int userId) {
+        return Transactions::exec("RefreshToken::listRefreshTokens", [&](pqxx::work& txn) {
+            const auto res = txn.exec(pqxx::prepped{"list_active_refresh_tokens_for_user"}, pqxx::params{userId});
 
-void RefreshToken::touch(const std::string& jti) {
-    Transactions::exec("RefreshToken::touchRefreshToken", [&](pqxx::work& txn) {
-        txn.exec(pqxx::prepped{"touch_refresh_token_last_used"}, pqxx::params{jti});
-    });
-}
+            std::vector<std::shared_ptr<vh::auth::model::RefreshToken>> tokens;
+            tokens.reserve(res.size());
 
-void RefreshToken::refresh(const std::string& jti) {
-    Transactions::exec("RefreshToken::revokeRefreshToken", [&](pqxx::work& txn) {
-        txn.exec(pqxx::prepped{"revoke_refresh_token_by_jti"}, pqxx::params{jti});
-    });
-}
+            for (const auto& row : res)
+                tokens.push_back(std::make_shared<vh::auth::model::RefreshToken>(row));
 
-void RefreshToken::revokeAll(const unsigned int userId) {
-    Transactions::exec("RefreshToken::revokeAllRefreshTokens", [&](pqxx::work& txn) {
-        txn.exec(pqxx::prepped{"revoke_all_refresh_tokens_for_user"}, pqxx::params{userId});
-    });
-}
-
-void RefreshToken::purgeExpired(const unsigned int userId) {
-    Transactions::exec("RefreshToken::purgeExpiredRefreshTokens", [&](pqxx::work& txn) {
-        txn.exec(pqxx::prepped{"delete_expired_refresh_tokens_for_user"}, pqxx::params{userId});
-    });
-}
-
-void RefreshToken::purgeOldRevoked() {
-    Transactions::exec("RefreshToken::purgeOldRevokedRefreshTokens", [&](pqxx::work& txn) {
-        txn.exec(pqxx::prepped{"delete_old_revoked_refresh_tokens_global"});
-    });
-}
-
-void RefreshToken::revokeAndPurge(const unsigned int userId) {
-    Transactions::exec("RefreshToken::revokeAndPurgeRefreshTokens", [&](pqxx::work& txn) {
-        txn.exec(pqxx::prepped{"revoke_all_refresh_tokens_for_user"}, pqxx::params{userId});
-        txn.exec(pqxx::prepped{"delete_expired_refresh_tokens_for_user"}, pqxx::params{userId});
-    });
-}
-
-std::shared_ptr<vh::identities::User> RefreshToken::getUserByJti(const std::string& jti) {
-    return Transactions::exec(
-        "RefreshToken::getUserByRefreshToken",
-        [&](pqxx::work& txn) -> std::shared_ptr<vh::identities::User> {
-            const auto res = txn.exec(pqxx::prepped{"get_user_by_refresh_token_jti"}, pqxx::params{jti});
-            return identities::hydrateUser(txn, res.one_row());
+            return tokens;
         });
+    }
+
+    void RefreshToken::touch(const std::string& jti) {
+        Transactions::exec("RefreshToken::touchRefreshToken", [&](pqxx::work& txn) {
+            txn.exec(pqxx::prepped{"touch_refresh_token_last_used"}, pqxx::params{jti});
+        });
+    }
+
+    void RefreshToken::refresh(const std::string& jti) {
+        Transactions::exec("RefreshToken::revokeRefreshToken", [&](pqxx::work& txn) {
+            txn.exec(pqxx::prepped{"revoke_refresh_token_by_jti"}, pqxx::params{jti});
+        });
+    }
+
+    void RefreshToken::revokeAll(const unsigned int userId) {
+        Transactions::exec("RefreshToken::revokeAllRefreshTokens", [&](pqxx::work& txn) {
+            txn.exec(pqxx::prepped{"revoke_all_refresh_tokens_for_user"}, pqxx::params{userId});
+        });
+    }
+
+    void RefreshToken::purgeExpired(const unsigned int userId) {
+        Transactions::exec("RefreshToken::purgeExpiredRefreshTokens", [&](pqxx::work& txn) {
+            txn.exec(pqxx::prepped{"delete_expired_refresh_tokens_for_user"}, pqxx::params{userId});
+        });
+    }
+
+    void RefreshToken::purgeOldRevoked() {
+        Transactions::exec("RefreshToken::purgeOldRevokedRefreshTokens", [&](pqxx::work& txn) {
+            txn.exec(pqxx::prepped{"delete_old_revoked_refresh_tokens_global"});
+        });
+    }
+
+    void RefreshToken::revokeAndPurge(const unsigned int userId) {
+        Transactions::exec("RefreshToken::revokeAndPurgeRefreshTokens", [&](pqxx::work& txn) {
+            txn.exec(pqxx::prepped{"revoke_all_refresh_tokens_for_user"}, pqxx::params{userId});
+            txn.exec(pqxx::prepped{"delete_expired_refresh_tokens_for_user"}, pqxx::params{userId});
+        });
+    }
+
+    std::shared_ptr<vh::identities::User> RefreshToken::getUserByJti(const std::string& jti) {
+        return Transactions::exec(
+            "RefreshToken::getUserByRefreshToken",
+            [&](pqxx::work& txn) -> std::shared_ptr<vh::identities::User> {
+                const auto res = txn.exec(pqxx::prepped{"get_user_by_refresh_token_jti"}, pqxx::params{jti});
+                return identities::hydrateUser(txn, res.one_row());
+            });
+    }
 }

--- a/src/db/query/identities/Group.cpp
+++ b/src/db/query/identities/Group.cpp
@@ -109,4 +109,12 @@ bool Group::groupExists(const std::string& name) {
     });
 }
 
+Group::GroupPtr Group::getGroupByLinuxGID(uint32_t gid) {
+    return Transactions::exec("Group::getGroupByLinuxGID", [&](pqxx::work& txn) -> GroupPtr {
+            const auto res = txn.exec(pqxx::prepped{"get_group_by_linux_gid"}, gid);
+            if (res.empty()) return nullptr;
+            return hydrateGroup(txn, res.one_row());
+        });
+}
+
 }

--- a/src/db/query/vault/APIKey.cpp
+++ b/src/db/query/vault/APIKey.cpp
@@ -5,74 +5,75 @@
 #include "identities/User.hpp"
 #include "db/query/identities/helpers.hpp"
 
-using namespace vh::db::query::vault;
 using namespace vh::db::model;
 using namespace vh::db::encoding;
 
-unsigned int APIKey::upsertAPIKey(const APIKeyPtr& key) {
-    return Transactions::exec("APIKey::addAPIKey", [&](pqxx::work& txn) {
-        pqxx::params p{
-            key->user_id,
-            key->name,
-            to_string(key->provider),
-            key->access_key,
-            to_hex_bytea(key->encrypted_secret_access_key),
-            to_hex_bytea(key->iv),
-            key->region,
-            key->endpoint
-        };
-        return txn.exec(pqxx::prepped{"upsert_api_key"}, p).one_field().as<unsigned int>();
-    });
-}
+namespace vh::db::query::vault {
+    unsigned int APIKey::upsertAPIKey(const std::shared_ptr<vh::vault::model::APIKey>& key) {
+        return Transactions::exec("APIKey::addAPIKey", [&](pqxx::work& txn) {
+            pqxx::params p{
+                key->user_id,
+                key->name,
+                to_string(key->provider),
+                key->access_key,
+                to_hex_bytea(key->encrypted_secret_access_key),
+                to_hex_bytea(key->iv),
+                key->region,
+                key->endpoint
+            };
+            return txn.exec(pqxx::prepped{"upsert_api_key"}, p).one_field().as<unsigned int>();
+        });
+    }
 
-void APIKey::removeAPIKey(const unsigned int keyId) {
-    Transactions::exec("APIKey::removeAPIKey", [&](pqxx::work& txn) {
-        txn.exec(pqxx::prepped{"remove_api_key"}, keyId);
-    });
-}
+    void APIKey::removeAPIKey(const unsigned int keyId) {
+        Transactions::exec("APIKey::removeAPIKey", [&](pqxx::work& txn) {
+            txn.exec(pqxx::prepped{"remove_api_key"}, keyId);
+        });
+    }
 
-std::vector<APIKey::APIKeyPtr> APIKey::listAPIKeys(const unsigned int userId, const ListQueryParams& params) {
-    return Transactions::exec("APIKey::listAPIKeys", [&](pqxx::work& txn) {
-        const auto sql = appendPaginationAndFilter(
-            "SELECT * FROM api_keys WHERE user_id = " + txn.quote(userId),
-            params, "id", "name"
-        );
-        return vh::vault::model::api_keys_from_pq_res(txn.exec(sql));
-    });
-}
+    std::vector<std::shared_ptr<vh::vault::model::APIKey>> APIKey::listAPIKeys(const unsigned int userId, const ListQueryParams& params) {
+        return Transactions::exec("APIKey::listAPIKeys", [&](pqxx::work& txn) {
+            const auto sql = appendPaginationAndFilter(
+                "SELECT * FROM api_keys WHERE user_id = " + txn.quote(userId),
+                params, "id", "name"
+            );
+            return vh::vault::model::api_keys_from_pq_res(txn.exec(sql));
+        });
+    }
 
-std::vector<APIKey::APIKeyPtr> APIKey::listAPIKeys(const ListQueryParams& params) {
-    return Transactions::exec("APIKey::listAPIKeys", [&](pqxx::work& txn) {
-        const auto sql = appendPaginationAndFilter(
-            "SELECT * FROM api_keys",
-            params, "id", "name"
-        );
-        return vh::vault::model::api_keys_from_pq_res(txn.exec(sql));
-    });
-}
+    std::vector<std::shared_ptr<vh::vault::model::APIKey>> APIKey::listAPIKeys(const ListQueryParams& params) {
+        return Transactions::exec("APIKey::listAPIKeys", [&](pqxx::work& txn) {
+            const auto sql = appendPaginationAndFilter(
+                "SELECT * FROM api_keys",
+                params, "id", "name"
+            );
+            return vh::vault::model::api_keys_from_pq_res(txn.exec(sql));
+        });
+    }
 
-APIKey::APIKeyPtr APIKey::getAPIKey(const unsigned int keyId) {
-    return Transactions::exec("APIKey::getAPIKey", [&](pqxx::work& txn) -> APIKeyPtr {
-        const auto res = txn.exec(pqxx::prepped{"get_api_key"}, keyId);
-        if (res.empty()) return nullptr;
-        return std::make_shared<AK>(res.one_row());
-    });
-}
+    std::shared_ptr<vh::vault::model::APIKey> APIKey::getAPIKey(const unsigned int keyId) {
+        return Transactions::exec("APIKey::getAPIKey", [&](pqxx::work& txn) -> std::shared_ptr<vh::vault::model::APIKey> {
+            const auto res = txn.exec(pqxx::prepped{"get_api_key"}, keyId);
+            if (res.empty()) return nullptr;
+            return std::make_shared<AK>(res.one_row());
+        });
+    }
 
-APIKey::APIKeyPtr APIKey::getAPIKey(const std::string& keyName) {
-    if (keyName.empty()) return nullptr;
+    std::shared_ptr<vh::vault::model::APIKey> APIKey::getAPIKey(const std::string& keyName) {
+        if (keyName.empty()) return nullptr;
 
-    return Transactions::exec("APIKey::getAPIKeyByName", [&](pqxx::work& txn) -> APIKeyPtr {
-        const auto res = txn.exec(pqxx::prepped{"get_api_key_by_name"}, keyName);
-        if (res.empty()) return nullptr;
-        return std::make_shared<AK>(res.one_row());
-    });
-}
+        return Transactions::exec("APIKey::getAPIKeyByName", [&](pqxx::work& txn) -> std::shared_ptr<vh::vault::model::APIKey> {
+            const auto res = txn.exec(pqxx::prepped{"get_api_key_by_name"}, keyName);
+            if (res.empty()) return nullptr;
+            return std::make_shared<AK>(res.one_row());
+        });
+    }
 
-std::shared_ptr<vh::identities::User> APIKey::getAPIKeyOwner(unsigned int keyId) {
-    return Transactions::exec("APIKey::getAPIKeyOwner", [&](pqxx::work& txn) -> std::shared_ptr<vh::identities::User> {
-        const auto res = txn.exec(pqxx::prepped{"get_api_key_owner"}, keyId);
-        if (res.empty()) return nullptr;
-        return identities::hydrateUser(txn, res.one_row());
-    });
+    std::shared_ptr<vh::identities::User> APIKey::getAPIKeyOwner(unsigned int keyId) {
+        return Transactions::exec("APIKey::getAPIKeyOwner", [&](pqxx::work& txn) -> std::shared_ptr<vh::identities::User> {
+            const auto res = txn.exec(pqxx::prepped{"get_api_key_owner"}, keyId);
+            if (res.empty()) return nullptr;
+            return identities::hydrateUser(txn, res.one_row());
+        });
+    }
 }

--- a/src/fs/Filesystem.cpp
+++ b/src/fs/Filesystem.cpp
@@ -26,6 +26,10 @@
 #include <fstream>
 #include <vector>
 #include <algorithm>
+#include <cerrno>
+#include <exception>
+#include <system_error>
+#include <ctime>
 #include <paths.h>
 
 using namespace vh::storage;
@@ -90,16 +94,26 @@ bool Filesystem::isReady() {
     return static_cast<bool>(storageManager_);
 }
 
-void Filesystem::mkdir(const std::filesystem::path& absPath, mode_t mode, const std::optional<unsigned int>& userId,
-                       std::shared_ptr<Engine> engine) {
+int Filesystem::mkdir(const std::filesystem::path& absPath,
+                      const mode_t mode,
+                      const std::optional<unsigned int>& userId,
+                      std::shared_ptr<Engine> engine) {
     log::Registry::fs()->debug("Creating directory at: {}", absPath.string());
-    std::scoped_lock lock(mutex_);
-    if (!storageManager_) throw std::runtime_error("StorageManager is not initialized");
 
-    const auto& cache = runtime::Deps::get().fsCache;
+    std::scoped_lock lock(mutex_);
 
     try {
-        if (absPath.empty()) throw std::runtime_error("Cannot create directory at empty path");
+        if (!storageManager_) {
+            log::Registry::fs()->error("[Filesystem::mkdir] StorageManager is not initialized");
+            return -EIO;
+        }
+
+        const auto& cache = runtime::Deps::get().fsCache;
+
+        if (absPath.empty()) {
+            log::Registry::fs()->error("[Filesystem::mkdir] Cannot create directory at empty path");
+            return -EINVAL;
+        }
 
         std::vector<std::filesystem::path> toCreate;
         std::filesystem::path cur = absPath;
@@ -111,7 +125,13 @@ void Filesystem::mkdir(const std::filesystem::path& absPath, mode_t mode, const 
 
         std::ranges::reverse(toCreate);
 
-        if (!engine) engine = storageManager_->resolveStorageEngine(absPath);
+        if (!engine)
+            engine = storageManager_->resolveStorageEngine(absPath);
+
+        if (!engine) {
+            log::Registry::fs()->error("[Filesystem::mkdir] No storage engine found for path: {}", absPath.string());
+            return -EIO;
+        }
 
         for (const auto& p : toCreate) {
             const auto path = makeAbsolute(p);
@@ -119,18 +139,15 @@ void Filesystem::mkdir(const std::filesystem::path& absPath, mode_t mode, const 
 
             auto dir = std::make_shared<Directory>();
 
-            if (engine) {
-                dir->vault_id = engine->vault->id;
-                dir->path = engine->paths->absRelToAbsRel(path, PathType::FUSE_ROOT, PathType::VAULT_ROOT);
-            } else dir->path = path;
+            dir->vault_id = engine->vault->id;
+            dir->path = engine->paths->absRelToAbsRel(path, PathType::FUSE_ROOT, PathType::VAULT_ROOT);
 
-            const auto parent = runtime::Deps::get().fsCache->getEntry(resolveParent(path));
+            const auto parent = cache->getEntry(resolveParent(path));
             if (!parent) {
-                log::Registry::fs()->error("[Filesystem::mkdir] Parent directory does not exist: {}", path.parent_path().string());
-                throw std::filesystem::filesystem_error(
-                    "Parent directory does not exist",
-                    path.parent_path(),
-                    std::make_error_code(std::errc::no_such_file_or_directory));
+                log::Registry::fs()->error(
+                    "[Filesystem::mkdir] Parent directory does not exist: {}",
+                    path.parent_path().string());
+                return -ENOENT;
             }
 
             dir->parent_id = parent->id;
@@ -142,7 +159,7 @@ void Filesystem::mkdir(const std::filesystem::path& absPath, mode_t mode, const 
             dir->owner_uid = getuid();
             dir->group_gid = getgid();
             dir->inode = cache->assignInode(path);
-            dir->is_hidden = dir->name.front() == '.' && !dir->name.starts_with("..");
+            dir->is_hidden = !dir->name.empty() && dir->name.front() == '.' && !dir->name.starts_with("..");
             dir->is_system = false;
             dir->created_by = dir->last_modified_by = userId;
 
@@ -151,16 +168,33 @@ void Filesystem::mkdir(const std::filesystem::path& absPath, mode_t mode, const 
 
             try {
                 std::filesystem::create_directories(dir->backing_path);
-            } catch (const std::exception& e) {
-                throw std::runtime_error(
-                    "Failed to create directory on disk: " + dir->backing_path.string() + " - " + e.what());
+            } catch (const std::filesystem::filesystem_error& e) {
+                log::Registry::fs()->error(
+                    "[Filesystem::mkdir] Failed to create backing directory {}: {}",
+                    dir->backing_path.string(),
+                    e.what());
+
+                if (e.code())
+                    return -e.code().value();
+
+                return -EIO;
             }
         }
 
         log::Registry::fs()->debug("Successfully created directory at: {}", absPath.string());
+        return 0;
+    } catch (const std::bad_alloc& ex) {
+        log::Registry::fs()->error("[Filesystem::mkdir] Out of memory for {}: {}", absPath.string(), ex.what());
+        return -ENOMEM;
+    } catch (const std::filesystem::filesystem_error& ex) {
+        log::Registry::fs()->error("[Filesystem::mkdir] Filesystem error for {}: {}", absPath.string(), ex.what());
+        return ex.code() ? -ex.code().value() : -EIO;
     } catch (const std::exception& ex) {
-        log::Registry::fs()->error("Failed to create directory: {} - {}", absPath.string(), ex.what());
-        throw std::runtime_error("Failed to create directory: " + absPath.string() + " - " + ex.what());
+        log::Registry::fs()->error("[Filesystem::mkdir] Failed to create directory {}: {}", absPath.string(), ex.what());
+        return -EIO;
+    } catch (...) {
+        log::Registry::fs()->error("[Filesystem::mkdir] Unknown failure creating directory: {}", absPath.string());
+        return -EIO;
     }
 }
 
@@ -215,45 +249,132 @@ bool Filesystem::exists(const std::filesystem::path& absPath) {
     }
 }
 
-void Filesystem::copy(const std::filesystem::path& from, const std::filesystem::path& to, unsigned int userId,
-                      std::shared_ptr<Engine> engine) {
-    if (from == to) return;
+int Filesystem::copy(const std::filesystem::path& from,
+                     const std::filesystem::path& to,
+                     const unsigned int userId,
+                     std::shared_ptr<Engine> engine) {
+    std::scoped_lock lock(mutex_);
 
-    if (!engine) engine = storageManager_->resolveStorageEngine(from);
-    if (!engine) throw std::runtime_error("[Filesystem] No storage engine found for copy operation");
+    try {
+        if (!storageManager_) {
+            log::Registry::fs()->error("[Filesystem::copy] StorageManager is not initialized");
+            return -EIO;
+        }
 
-    const auto toEngine = storageManager_->resolveStorageEngine(to);
-    if (!toEngine) throw std::runtime_error("[Filesystem] No storage engine found for destination of copy operation");
-    if (toEngine->vault->id != engine->vault->id)
-        throw std::runtime_error("[Filesystem] Cross-vault copy operations are not supported");
+        if (from == to)
+            return 0;
 
-    const auto fromVaultPath = engine->paths->absRelToAbsRel(from, PathType::FUSE_ROOT, PathType::VAULT_ROOT);
-    const auto toVaultPath = engine->paths->absRelToAbsRel(to, PathType::FUSE_ROOT, PathType::VAULT_ROOT);
+        if (!engine)
+            engine = storageManager_->resolveStorageEngine(from);
 
-    const bool isFile = engine->isFile(fromVaultPath);
-    if (!isFile && !engine->isDirectory(fromVaultPath))
-        throw std::runtime_error("[StorageEngine] Path does not exist: " + fromVaultPath.string());
+        if (!engine) {
+            log::Registry::fs()->error(
+                "[Filesystem::copy] No storage engine found for source path: {}",
+                from.string());
+            return -EIO;
+        }
 
-    const auto& cache = runtime::Deps::get().fsCache;
+        const auto toEngine = storageManager_->resolveStorageEngine(to);
+        if (!toEngine) {
+            log::Registry::fs()->error(
+                "[Filesystem::copy] No storage engine found for destination path: {}",
+                to.string());
+            return -EIO;
+        }
 
-    const auto entry = cache->getEntry(from);
+        if (toEngine->vault->id != engine->vault->id) {
+            log::Registry::fs()->error(
+                "[Filesystem::copy] Cross-vault copy not supported: {} -> {}",
+                from.string(),
+                to.string());
+            return -EXDEV;
+        }
 
-    const auto parent = runtime::Deps::get().fsCache->getEntry(resolveParent(to));
+        const auto fromVaultPath = engine->paths->absRelToAbsRel(from, PathType::FUSE_ROOT, PathType::VAULT_ROOT);
+        const auto toVaultPath = engine->paths->absRelToAbsRel(to, PathType::FUSE_ROOT, PathType::VAULT_ROOT);
 
-    entry->id = 0;
-    entry->path = toVaultPath;
-    entry->fuse_path = to;
-    entry->name = to.filename().string();
-    entry->base32_alias = id::Generator({ .namespace_token = entry->name }).generate();
-    entry->backing_path = parent->backing_path / entry->base32_alias;
-    entry->created_by = entry->last_modified_by = userId;
-    entry->parent_id = parent->id;
-    entry->inode = cache->getOrAssignInode(to);
-    entry->is_hidden = entry->name.front() == '.' && !entry->name.starts_with("..");
-    entry->is_system = false;
+        const bool isFile = engine->isFile(fromVaultPath);
+        if (!isFile && !engine->isDirectory(fromVaultPath)) {
+            log::Registry::fs()->error(
+                "[Filesystem::copy] Source path does not exist: {}",
+                from.string());
+            return -ENOENT;
+        }
 
-    if (isFile) db::query::fs::File::upsertFile(std::make_shared<File>(*std::static_pointer_cast<File>(entry)));
-    else db::query::fs::Directory::upsertDirectory(std::make_shared<Directory>(*std::static_pointer_cast<Directory>(entry)));
+        const auto& cache = runtime::Deps::get().fsCache;
+
+        const auto entry = cache->getEntry(from);
+        if (!entry) {
+            log::Registry::fs()->error(
+                "[Filesystem::copy] Source entry not found in cache: {}",
+                from.string());
+            return -ENOENT;
+        }
+
+        const auto parent = cache->getEntry(resolveParent(to));
+        if (!parent) {
+            log::Registry::fs()->error(
+                "[Filesystem::copy] Destination parent does not exist: {}",
+                to.parent_path().string());
+            return -ENOENT;
+        }
+
+        if (cache->entryExists(to)) {
+            log::Registry::fs()->error(
+                "[Filesystem::copy] Destination already exists: {}",
+                to.string());
+            return -EEXIST;
+        }
+
+        if (isFile) {
+            auto copied = std::make_shared<File>(*std::static_pointer_cast<File>(entry));
+            copied->id = 0;
+            copied->path = toVaultPath;
+            copied->fuse_path = to;
+            copied->name = to.filename().string();
+            copied->base32_alias = id::Generator({ .namespace_token = copied->name }).generate();
+            copied->backing_path = parent->backing_path / copied->base32_alias;
+            copied->created_by = copied->last_modified_by = userId;
+            copied->parent_id = parent->id;
+            copied->inode = cache->getOrAssignInode(to);
+            copied->is_hidden = !copied->name.empty() && copied->name.front() == '.' && !copied->name.starts_with("..");
+            copied->is_system = false;
+
+            copied->id = db::query::fs::File::upsertFile(copied);
+            cache->cacheEntry(copied);
+        } else {
+            auto copied = std::make_shared<Directory>(*std::static_pointer_cast<Directory>(entry));
+            copied->id = 0;
+            copied->path = toVaultPath;
+            copied->fuse_path = to;
+            copied->name = to.filename().string();
+            copied->base32_alias = id::Generator({ .namespace_token = copied->name }).generate();
+            copied->backing_path = parent->backing_path / copied->base32_alias;
+            copied->created_by = copied->last_modified_by = userId;
+            copied->parent_id = parent->id;
+            copied->inode = cache->getOrAssignInode(to);
+            copied->is_hidden = !copied->name.empty() && copied->name.front() == '.' && !copied->name.starts_with("..");
+            copied->is_system = false;
+
+            copied->id = db::query::fs::Directory::upsertDirectory(copied);
+            cache->cacheEntry(copied);
+        }
+
+        log::Registry::fs()->debug("[Filesystem::copy] Successfully copied {} -> {}", from.string(), to.string());
+        return 0;
+    } catch (const std::bad_alloc& ex) {
+        log::Registry::fs()->error("[Filesystem::copy] Out of memory copying {} -> {}: {}", from.string(), to.string(), ex.what());
+        return -ENOMEM;
+    } catch (const std::filesystem::filesystem_error& ex) {
+        log::Registry::fs()->error("[Filesystem::copy] Filesystem error copying {} -> {}: {}", from.string(), to.string(), ex.what());
+        return ex.code() ? -ex.code().value() : -EIO;
+    } catch (const std::exception& ex) {
+        log::Registry::fs()->error("[Filesystem::copy] Failed to copy {} -> {}: {}", from.string(), to.string(), ex.what());
+        return -EIO;
+    } catch (...) {
+        log::Registry::fs()->error("[Filesystem::copy] Unknown failure copying {} -> {}", from.string(), to.string());
+        return -EIO;
+    }
 }
 
 void Filesystem::remove(const std::filesystem::path& path, const unsigned int userId) {
@@ -277,50 +398,6 @@ void Filesystem::remove(const std::filesystem::path& path, const unsigned int us
     }
 
     if (std::filesystem::exists(entry->backing_path)) std::filesystem::remove_all(entry->backing_path);
-}
-
-std::shared_ptr<Entry> Filesystem::createFile(const std::filesystem::path& path, uid_t uid, gid_t gid, mode_t mode) {
-    const auto engine = storageManager_->resolveStorageEngine(path);
-    if (!engine) {
-        log::Registry::fs()->error("No storage engine found for file creation at path: {}", path.string());
-        return nullptr;
-    }
-
-    const auto& cache = runtime::Deps::get().fsCache;
-
-    log::Registry::fs()->debug("Creating file at path: {}", path.string());
-
-    const auto parent = runtime::Deps::get().fsCache->getEntry(resolveParent(path));
-
-    const auto f = std::make_shared<File>();
-    f->parent_id = parent->id;
-    f->vault_id = engine->vault->id;
-    f->name = path.filename();
-    f->path = engine->paths->absRelToAbsRel(path, PathType::FUSE_ROOT, PathType::VAULT_ROOT);
-    f->fuse_path = path;
-    f->base32_alias = id::Generator({ .namespace_token = f->name }).generate();
-    f->backing_path = parent->backing_path / f->base32_alias;
-    f->mode = mode;
-    f->owner_uid = uid;
-    f->group_gid = gid;
-    f->is_hidden = path.filename().string().starts_with('.');
-    f->created_at = std::time(nullptr);
-    f->updated_at = f->created_at;
-    f->inode = std::make_optional(cache->getOrAssignInode(path));
-    f->mime_type = inferMimeTypeFromPath(path.filename());
-    f->size_bytes = 0;
-
-    std::filesystem::create_directories(f->backing_path.parent_path());
-    std::ofstream(f->backing_path).close(); // create empty file
-    if (!std::filesystem::exists(f->backing_path))
-        throw std::runtime_error("[Filesystem] Failed to create real file at: " + f->backing_path.string());
-
-    f->content_hash = hash::blake2b(f->backing_path);
-    f->id = db::query::fs::File::upsertFile(f);
-    cache->cacheEntry(f);
-
-    log::Registry::fs()->debug("Successfully created file at path: {}", path.string());
-    return f;
 }
 
 std::shared_ptr<File> Filesystem::createFile(const NewFileContext& ctx) {
@@ -420,156 +497,409 @@ std::shared_ptr<File> Filesystem::createFile(const NewFileContext& ctx) {
     return f;
 }
 
-void Filesystem::rename(const std::filesystem::path& oldPath, const std::filesystem::path& newPath, const std::optional<unsigned int>& userId,
-                        std::shared_ptr<Engine> engine) {
-    log::Registry::fs()->debug("Renaming {} to {}", oldPath.string(), newPath.string());
+std::pair<int, std::shared_ptr<model::Entry>>
+Filesystem::createFile(const std::filesystem::path& path,
+                       const uid_t uid,
+                       const gid_t gid,
+                       const mode_t mode) {
+    std::scoped_lock lock(mutex_);
 
-    const auto entry = runtime::Deps::get().fsCache->getEntry(oldPath);
-    if (!engine) engine = storageManager_->resolveStorageEngine(oldPath);
-    if (!engine) {
-        throw std::filesystem::filesystem_error(
-            "[Filesystem] No storage engine found for DB-backed rename",
-            oldPath,
-            std::make_error_code(std::errc::no_such_file_or_directory));
-    }
-
-    const auto toEngine = storageManager_->resolveStorageEngine(newPath);
-    if (!toEngine) throw std::runtime_error("[Filesystem] No storage engine found for destination of copy operation");
-    if (toEngine->vault->id != engine->vault->id)
-        throw std::runtime_error("[Filesystem] Cross-vault copy operations are not supported");
-
-    const auto oldBackingPath = entry->backing_path;
-
-    db::Transactions::exec("Filesystem::rename", [&](pqxx::work& txn) {
-        std::vector<uint8_t> buffer;
-        if (entry->isDirectory()) {
-            if (!entry->parent_id) {
-                log::Registry::fs()->error("Cannot rename root directory: {}", oldPath.string());
-                throw std::runtime_error("[Filesystem] Cannot rename root directory");
-            }
-
-            for (const auto& item : runtime::Deps::get().fsCache->listDir(*entry->parent_id, true)) {
-                handleRename({
-                    .from = item->fuse_path,
-                    .to = updateSubdirPath(oldPath, newPath, item->fuse_path),
-                    .buffer = buffer,
-                    .userId = userId,
-                    .engine = engine,
-                    .entry = item,
-                    .txn = txn
-                });
-                buffer.clear();
-            }
+    try {
+        if (!storageManager_) {
+            log::Registry::fs()->error("[Filesystem::createFile] StorageManager is not initialized");
+            return {-EIO, nullptr};
         }
 
-        handleRename({
-            .from = oldPath,
-            .to = newPath,
-            .buffer = buffer,
-            .userId = userId,
-            .engine = engine,
-            .entry = entry,
-            .txn = txn
-        });
+        const auto engine = storageManager_->resolveStorageEngine(path);
+        if (!engine) {
+            log::Registry::fs()->error(
+                "[Filesystem::createFile] No storage engine found for path: {}",
+                path.string());
+            return {-EIO, nullptr};
+        }
 
-        txn.commit();
+        const auto& cache = runtime::Deps::get().fsCache;
 
-        if (entry->backing_path != oldBackingPath) std::filesystem::remove_all(oldBackingPath);
-    });
+        log::Registry::fs()->debug("[Filesystem::createFile] Creating file at path: {}", path.string());
 
-    runtime::Deps::get().fsCache->evictPath(oldPath);
-    runtime::Deps::get().fsCache->evictPath(newPath);
-    runtime::Deps::get().fsCache->cacheEntry(entry);
+        const auto parent = cache->getEntry(resolveParent(path));
+        if (!parent) {
+            log::Registry::fs()->error(
+                "[Filesystem::createFile] Parent directory does not exist: {}",
+                path.parent_path().string());
+            return {-ENOENT, nullptr};
+        }
 
-    log::Registry::fs()->debug("Successfully renamed {} to {}", oldPath.string(), newPath.string());
+        if (cache->entryExists(path)) {
+            log::Registry::fs()->error(
+                "[Filesystem::createFile] File already exists: {}",
+                path.string());
+            return {-EEXIST, nullptr};
+        }
+
+        auto f = std::make_shared<File>();
+        f->parent_id = parent->id;
+        f->vault_id = engine->vault->id;
+        f->name = path.filename();
+        f->path = engine->paths->absRelToAbsRel(path, PathType::FUSE_ROOT, PathType::VAULT_ROOT);
+        f->fuse_path = path;
+        f->base32_alias = id::Generator({ .namespace_token = f->name }).generate();
+        f->backing_path = parent->backing_path / f->base32_alias;
+        f->mode = mode;
+        f->owner_uid = uid;
+        f->group_gid = gid;
+        f->is_hidden = !f->name.empty() && f->name.starts_with('.');
+        f->created_at = std::time(nullptr);
+        f->updated_at = f->created_at;
+        f->inode = std::make_optional(cache->getOrAssignInode(path));
+        f->mime_type = inferMimeTypeFromPath(path.filename());
+        f->size_bytes = 0;
+
+        try {
+            std::filesystem::create_directories(f->backing_path.parent_path());
+            std::ofstream(f->backing_path).close();
+        } catch (const std::filesystem::filesystem_error& ex) {
+            log::Registry::fs()->error(
+                "[Filesystem::createFile] Failed to create backing file for {}: {}",
+                path.string(),
+                ex.what());
+            return {ex.code() ? -ex.code().value() : -EIO, nullptr};
+        } catch (const std::exception& ex) {
+            log::Registry::fs()->error(
+                "[Filesystem::createFile] Failed to create backing file for {}: {}",
+                path.string(),
+                ex.what());
+            return {-EIO, nullptr};
+        }
+
+        if (!std::filesystem::exists(f->backing_path)) {
+            log::Registry::fs()->error(
+                "[Filesystem::createFile] Failed to create real file at: {}",
+                f->backing_path.string());
+            return {-EIO, nullptr};
+        }
+
+        f->content_hash = hash::blake2b(f->backing_path);
+        f->id = db::query::fs::File::upsertFile(f);
+        cache->cacheEntry(f);
+
+        log::Registry::fs()->debug("[Filesystem::createFile] Successfully created file at path: {}", path.string());
+        return {0, f};
+    } catch (const std::bad_alloc& ex) {
+        log::Registry::fs()->error(
+            "[Filesystem::createFile] Out of memory creating {}: {}",
+            path.string(),
+            ex.what());
+        return {-ENOMEM, nullptr};
+    } catch (const std::filesystem::filesystem_error& ex) {
+        log::Registry::fs()->error(
+            "[Filesystem::createFile] Filesystem error creating {}: {}",
+            path.string(),
+            ex.what());
+        return {ex.code() ? -ex.code().value() : -EIO, nullptr};
+    } catch (const std::exception& ex) {
+        log::Registry::fs()->error(
+            "[Filesystem::createFile] Failed to create file at path {}: {}",
+            path.string(),
+            ex.what());
+        return {-EIO, nullptr};
+    } catch (...) {
+        log::Registry::fs()->error(
+            "[Filesystem::createFile] Unknown failure creating file at path: {}",
+            path.string());
+        return {-EIO, nullptr};
+    }
 }
 
-void Filesystem::handleRename(const RenameContext& ctx) {
-    const auto& cache = runtime::Deps::get().fsCache;
+int Filesystem::rename(const std::filesystem::path& oldPath,
+                       const std::filesystem::path& newPath,
+                       const std::optional<unsigned int>& userId,
+                       std::shared_ptr<Engine> engine) {
+    std::scoped_lock lock(mutex_);
 
-    const auto oldBackingPath = ctx.entry->backing_path;
-    if (!std::filesystem::exists(oldBackingPath)) {
-        throw std::filesystem::filesystem_error(
-            "[Filesystem] Source path does not exist: " + oldBackingPath.string(),
-            oldBackingPath,
-            std::make_error_code(std::errc::no_such_file_or_directory));
-    }
+    try {
+        log::Registry::fs()->debug("[Filesystem::rename] Renaming {} to {}", oldPath.string(), newPath.string());
 
-    const auto& entry = ctx.entry;
-
-    unsigned int id = 0;
-    if (entry->id == 0) {
-        const auto e = runtime::Deps::get().fsCache->getEntry(entry->fuse_path);
-        if (e) id = e->id;
-        else id = 0;
-    }
-    else id = entry->id;
-
-    const auto parent = runtime::Deps::get().fsCache->getEntry(resolveParent(ctx.to));
-    if (!parent) throw std::runtime_error("Parent directory does not exist: " + resolveParent(ctx.to).string());
-
-    const auto oldVaultPath = ctx.entry->path;
-
-    entry->id = id;
-    entry->name = ctx.to.filename();
-    entry->path = ctx.engine->paths->absRelToAbsRel(ctx.to, PathType::FUSE_ROOT, PathType::VAULT_ROOT);
-    entry->fuse_path = ctx.to;
-    entry->parent_id = parent->id;
-    entry->created_by = entry->last_modified_by = ctx.userId;
-
-    entry->backing_path = parent->backing_path / entry->base32_alias;
-
-    if (entry->isDirectory()) std::filesystem::create_directories(entry->backing_path);
-    else {
-        std::filesystem::create_directories(entry->backing_path.parent_path());
-        const auto f = std::static_pointer_cast<File>(entry);
-
-        if (canFastPath(entry, ctx.engine)) {
-            log::Registry::fs()->debug("Fast path rename for file: {}", ctx.from.string());
-
-            std::filesystem::rename(oldBackingPath, entry->backing_path);
-            updateFSEntry(ctx.txn, entry);
-
-            cache->evictPath(ctx.from);
-            cache->evictPath(ctx.to);
-            cache->cacheEntry(entry);
-            return; // bail early, no reencrypt
+        if (!storageManager_) {
+            log::Registry::fs()->error("[Filesystem::rename] StorageManager is not initialized");
+            return -EIO;
         }
 
-        auto buffer = ctx.buffer;
+        if (oldPath == newPath)
+            return 0;
 
-        if (!f->encryption_iv.empty()) {
-            const auto tmp = decrypt_file_to_temp(ctx.engine->vault->id, oldVaultPath, ctx.engine);
-            buffer = readFileToVector(tmp);
-        } else buffer = readFileToVector(oldBackingPath);
+        const auto entry = runtime::Deps::get().fsCache->getEntry(oldPath);
+        if (!entry) {
+            log::Registry::fs()->error(
+                "[Filesystem::rename] Source entry not found: {}",
+                oldPath.string());
+            return -ENOENT;
+        }
 
-        if (buffer.empty()) {
-            std::ofstream(entry->backing_path).close();
-            if (!std::filesystem::exists(entry->backing_path))
-                throw std::runtime_error("Failed to create real file at: " + entry->backing_path.string());
+        if (!engine)
+            engine = storageManager_->resolveStorageEngine(oldPath);
+
+        if (!engine) {
+            log::Registry::fs()->error(
+                "[Filesystem::rename] No storage engine found for source path: {}",
+                oldPath.string());
+            return -ENOENT;
+        }
+
+        const auto toEngine = storageManager_->resolveStorageEngine(newPath);
+        if (!toEngine) {
+            log::Registry::fs()->error(
+                "[Filesystem::rename] No storage engine found for destination path: {}",
+                newPath.string());
+            return -ENOENT;
+        }
+
+        if (toEngine->vault->id != engine->vault->id) {
+            log::Registry::fs()->error(
+                "[Filesystem::rename] Cross-vault rename not supported: {} -> {}",
+                oldPath.string(),
+                newPath.string());
+            return -EXDEV;
+        }
+
+        const auto oldBackingPath = entry->backing_path;
+
+        int rc = 0;
+
+        db::Transactions::exec("Filesystem::rename", [&](pqxx::work& txn) {
+            std::vector<uint8_t> buffer;
+
+            if (entry->isDirectory()) {
+                if (!entry->parent_id) {
+                    log::Registry::fs()->error(
+                        "[Filesystem::rename] Cannot rename root directory: {}",
+                        oldPath.string());
+                    rc = -EBUSY;
+                    return;
+                }
+
+                for (const auto& item : runtime::Deps::get().fsCache->listDir(*entry->parent_id, true)) {
+                    rc = handleRename({
+                        .from = item->fuse_path,
+                        .to = updateSubdirPath(oldPath, newPath, item->fuse_path),
+                        .buffer = buffer,
+                        .userId = userId,
+                        .engine = engine,
+                        .entry = item,
+                        .txn = txn
+                    });
+
+                    if (rc != 0)
+                        return;
+
+                    buffer.clear();
+                }
+            }
+
+            rc = handleRename({
+                .from = oldPath,
+                .to = newPath,
+                .buffer = buffer,
+                .userId = userId,
+                .engine = engine,
+                .entry = entry,
+                .txn = txn
+            });
+
+            if (rc != 0)
+                return;
+
+            txn.commit();
+
+            try {
+                if (entry->backing_path != oldBackingPath)
+                    std::filesystem::remove_all(oldBackingPath);
+            } catch (const std::filesystem::filesystem_error& ex) {
+                log::Registry::fs()->warn(
+                    "[Filesystem::rename] Renamed successfully but failed to remove old backing path {}: {}",
+                    oldBackingPath.string(),
+                    ex.what());
+            }
+        });
+
+        if (rc != 0)
+            return rc;
+
+        runtime::Deps::get().fsCache->evictPath(oldPath);
+        runtime::Deps::get().fsCache->evictPath(newPath);
+        runtime::Deps::get().fsCache->cacheEntry(entry);
+
+        log::Registry::fs()->debug("[Filesystem::rename] Successfully renamed {} to {}", oldPath.string(), newPath.string());
+        return 0;
+    } catch (const std::bad_alloc& ex) {
+        log::Registry::fs()->error(
+            "[Filesystem::rename] Out of memory renaming {} -> {}: {}",
+            oldPath.string(),
+            newPath.string(),
+            ex.what());
+        return -ENOMEM;
+    } catch (const std::filesystem::filesystem_error& ex) {
+        log::Registry::fs()->error(
+            "[Filesystem::rename] Filesystem error renaming {} -> {}: {}",
+            oldPath.string(),
+            newPath.string(),
+            ex.what());
+        return ex.code() ? -ex.code().value() : -EIO;
+    } catch (const std::exception& ex) {
+        log::Registry::fs()->error(
+            "[Filesystem::rename] Failed to rename {} -> {}: {}",
+            oldPath.string(),
+            newPath.string(),
+            ex.what());
+        return -EIO;
+    } catch (...) {
+        log::Registry::fs()->error(
+            "[Filesystem::rename] Unknown failure renaming {} -> {}",
+            oldPath.string(),
+            newPath.string());
+        return -EIO;
+    }
+}
+
+int Filesystem::handleRename(const RenameContext& ctx) {
+    try {
+        const auto& cache = runtime::Deps::get().fsCache;
+        const auto& entry = ctx.entry;
+
+        if (!entry) {
+            log::Registry::fs()->error("[Filesystem::handleRename] Null entry for {} -> {}", ctx.from.string(), ctx.to.string());
+            return -EINVAL;
+        }
+
+        const auto oldBackingPath = entry->backing_path;
+        if (!std::filesystem::exists(oldBackingPath)) {
+            log::Registry::fs()->error(
+                "[Filesystem::handleRename] Source backing path does not exist: {}",
+                oldBackingPath.string());
+            return -ENOENT;
+        }
+
+        unsigned int id = 0;
+        if (entry->id == 0) {
+            const auto e = cache->getEntry(entry->fuse_path);
+            id = e ? e->id : 0;
         } else {
-            const auto ciphertext = ctx.engine->encryptionManager->encrypt(buffer, f);
-            if (ciphertext.empty()) throw std::runtime_error("Encryption failed for file: " + oldBackingPath.string());
-            writeFile(entry->backing_path, ciphertext);
-
-            f->size_bytes = std::filesystem::file_size(entry->backing_path);
-            f->mime_type = Magic::get_mime_type_from_buffer(buffer);
-            f->content_hash = hash::blake2b(entry->backing_path);
-
-            if (f->size_bytes > 0 && f->mime_type && isPreviewable(*f->mime_type))
-                preview::thumbnail::Worker::enqueue(ctx.engine, buffer, f);
-
-            updateFile(ctx.txn, f);
+            id = entry->id;
         }
+
+        const auto parent = cache->getEntry(resolveParent(ctx.to));
+        if (!parent) {
+            log::Registry::fs()->error(
+                "[Filesystem::handleRename] Parent directory does not exist: {}",
+                resolveParent(ctx.to).string());
+            return -ENOENT;
+        }
+
+        const auto oldVaultPath = entry->path;
+
+        entry->id = id;
+        entry->name = ctx.to.filename();
+        entry->path = ctx.engine->paths->absRelToAbsRel(ctx.to, PathType::FUSE_ROOT, PathType::VAULT_ROOT);
+        entry->fuse_path = ctx.to;
+        entry->parent_id = parent->id;
+        entry->created_by = entry->last_modified_by = ctx.userId;
+        entry->backing_path = parent->backing_path / entry->base32_alias;
+
+        if (entry->isDirectory()) {
+            std::filesystem::create_directories(entry->backing_path);
+        } else {
+            std::filesystem::create_directories(entry->backing_path.parent_path());
+
+            const auto f = std::static_pointer_cast<File>(entry);
+
+            if (canFastPath(entry, ctx.engine)) {
+                log::Registry::fs()->debug("[Filesystem::handleRename] Fast path rename for file: {}", ctx.from.string());
+
+                std::filesystem::rename(oldBackingPath, entry->backing_path);
+                updateFSEntry(ctx.txn, entry);
+
+                cache->evictPath(ctx.from);
+                cache->evictPath(ctx.to);
+                cache->cacheEntry(entry);
+                return 0;
+            }
+
+            auto buffer = ctx.buffer;
+
+            if (!f->encryption_iv.empty()) {
+                const auto tmp = decrypt_file_to_temp(ctx.engine->vault->id, oldVaultPath, ctx.engine);
+                buffer = readFileToVector(tmp);
+            } else {
+                buffer = readFileToVector(oldBackingPath);
+            }
+
+            if (buffer.empty()) {
+                std::ofstream(entry->backing_path).close();
+
+                if (!std::filesystem::exists(entry->backing_path)) {
+                    log::Registry::fs()->error(
+                        "[Filesystem::handleRename] Failed to create real file at: {}",
+                        entry->backing_path.string());
+                    return -EIO;
+                }
+            } else {
+                const auto ciphertext = ctx.engine->encryptionManager->encrypt(buffer, f);
+                if (ciphertext.empty()) {
+                    log::Registry::fs()->error(
+                        "[Filesystem::handleRename] Encryption failed for file: {}",
+                        oldBackingPath.string());
+                    return -EIO;
+                }
+
+                writeFile(entry->backing_path, ciphertext);
+
+                f->size_bytes = std::filesystem::file_size(entry->backing_path);
+                f->mime_type = Magic::get_mime_type_from_buffer(buffer);
+                f->content_hash = hash::blake2b(entry->backing_path);
+
+                if (f->size_bytes > 0 && f->mime_type && isPreviewable(*f->mime_type))
+                    preview::thumbnail::Worker::enqueue(ctx.engine, buffer, f);
+
+                updateFile(ctx.txn, f);
+            }
+        }
+
+        updateFSEntry(ctx.txn, entry);
+
+        cache->evictPath(ctx.from);
+        cache->evictPath(ctx.to);
+        cache->cacheEntry(entry);
+
+        log::Registry::fs()->debug("[Filesystem::handleRename] Renamed {} to {}", ctx.from.string(), ctx.to.string());
+        return 0;
+    } catch (const std::bad_alloc& ex) {
+        log::Registry::fs()->error(
+            "[Filesystem::handleRename] Out of memory renaming {} -> {}: {}",
+            ctx.from.string(),
+            ctx.to.string(),
+            ex.what());
+        return -ENOMEM;
+    } catch (const std::filesystem::filesystem_error& ex) {
+        log::Registry::fs()->error(
+            "[Filesystem::handleRename] Filesystem error renaming {} -> {}: {}",
+            ctx.from.string(),
+            ctx.to.string(),
+            ex.what());
+        return ex.code() ? -ex.code().value() : -EIO;
+    } catch (const std::exception& ex) {
+        log::Registry::fs()->error(
+            "[Filesystem::handleRename] Failed to rename {} -> {}: {}",
+            ctx.from.string(),
+            ctx.to.string(),
+            ex.what());
+        return -EIO;
+    } catch (...) {
+        log::Registry::fs()->error(
+            "[Filesystem::handleRename] Unknown failure renaming {} -> {}",
+            ctx.from.string(),
+            ctx.to.string());
+        return -EIO;
     }
-
-    updateFSEntry(ctx.txn, entry);
-
-    cache->evictPath(ctx.from);
-    cache->evictPath(ctx.to);
-    cache->cacheEntry(entry);
-
-    log::Registry::fs()->debug("Renamed {} to {}", ctx.from.string(), ctx.to.string());
 }
 
 bool Filesystem::canFastPath(const std::shared_ptr<Entry>& entry, const std::shared_ptr<Engine>& engine) {

--- a/src/fuse/Bridge.cpp
+++ b/src/fuse/Bridge.cpp
@@ -70,7 +70,7 @@ void getattr(const fuse_req_t req, const fuse_ino_t ino, fuse_file_info* fi) {
             return;
         }
 
-        if (!resolver::Vault::has<permission::vault::FilesystemAction>({
+        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::List,
             .entry = entry
@@ -124,7 +124,7 @@ void setattr(const fuse_req_t req, const fuse_ino_t ino,
             return;
         }
 
-        if (!resolver::Vault::has<permission::vault::FilesystemAction>({
+        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::Upload,
             .entry = entry
@@ -179,7 +179,7 @@ void readdir(const fuse_req_t req, const fuse_ino_t ino, const size_t size, cons
         return;
     }
 
-    if (!resolver::Vault::has<permission::vault::FilesystemAction>({
+    if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::List,
             .entry = entry
@@ -263,7 +263,7 @@ void lookup(const fuse_req_t req, const fuse_ino_t parent, const char* name) {
         return;
     }
 
-    if (!resolver::Vault::has<permission::vault::FilesystemAction>({
+    if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::List,
             .entry = entry
@@ -315,7 +315,7 @@ void create(const fuse_req_t req, const fuse_ino_t parent, const char* name, con
             return;
         }
 
-        if (!resolver::Vault::has<permission::vault::FilesystemAction>({
+        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::Upload,
             .path = vaultPath,
@@ -383,7 +383,7 @@ void open(const fuse_req_t req, const fuse_ino_t ino, fuse_file_info* fi) {
             return;
         }
 
-        if (!resolver::Vault::has<permission::vault::FilesystemAction>({
+        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::Download,
             .entry = entry
@@ -442,7 +442,7 @@ void write(const fuse_req_t req, const fuse_ino_t ino, const char* buf,
         return;
     }
 
-    if (!resolver::Vault::has<permission::vault::FilesystemAction>({
+    if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::Upload,
             .entry = entry
@@ -483,7 +483,7 @@ void read(const fuse_req_t req, const fuse_ino_t ino, const size_t size, const o
         return;
     }
 
-    if (!resolver::Vault::has<permission::vault::FilesystemAction>({
+    if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::Download,
             .entry = entry
@@ -537,7 +537,7 @@ void mkdir(const fuse_req_t req, const fuse_ino_t parent, const char* name, cons
         }
 
         const auto vaultPath = engine->paths->absRelToAbsRel(fullPath, PathType::FUSE_ROOT, PathType::VAULT_ROOT);
-        if (!resolver::Vault::has<permission::vault::FilesystemAction>({
+        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::Touch,
             .path = vaultPath,
@@ -606,7 +606,7 @@ void rename(const fuse_req_t req, const fuse_ino_t parent, const char* name, con
             return;
         }
 
-        if (!resolver::Vault::has<permission::vault::FilesystemAction>({
+        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::Rename,
             .entry = entry
@@ -668,19 +668,19 @@ void access(const fuse_req_t req, const fuse_ino_t ino, const int mask) {
     if (entry->vault_id) {
         bool allowed = true;
 
-        if ((mask & R_OK) && !resolver::Vault::has<permission::vault::FilesystemAction>({
+        if ((mask & R_OK) && !rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::Download,
             .entry = entry
         })) allowed = false;
 
-        if ((mask & W_OK) && !resolver::Vault::has<permission::vault::FilesystemAction>({
+        if ((mask & W_OK) && !rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::Upload,
             .entry = entry
         })) allowed = false;
 
-        if ((mask & X_OK) && !resolver::Vault::has<permission::vault::FilesystemAction>({
+        if ((mask & X_OK) && !rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::List,
             .entry = entry
@@ -734,7 +734,7 @@ void unlink(const fuse_req_t req, const fuse_ino_t parent, const char* name) {
             return;
         }
 
-        if (!resolver::Vault::has<permission::vault::FilesystemAction>({
+        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::Delete,
             .entry = file
@@ -797,7 +797,7 @@ void rmdir(const fuse_req_t req, const fuse_ino_t parent, const char* name) {
             return;
         }
 
-        if (!resolver::Vault::has<permission::vault::FilesystemAction>({
+        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::Delete,
             .entry = entry
@@ -871,7 +871,7 @@ void fsync(const fuse_req_t req, const fuse_ino_t ino, const int datasync, fuse_
         return;
     }
 
-    if (!resolver::Vault::has<permission::vault::FilesystemAction>({
+    if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::Upload,
             .entry = entry
@@ -917,7 +917,7 @@ void statfs(const fuse_req_t req, const fuse_ino_t ino) {
             return;
         }
 
-        if (!resolver::Vault::has<permission::vault::FilesystemAction>({
+        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
             .user = user,
             .permission = permission::vault::FilesystemAction::Download,
             .entry = entry

--- a/src/fuse/Bridge.cpp
+++ b/src/fuse/Bridge.cpp
@@ -14,6 +14,7 @@
 #include "log/Registry.hpp"
 #include "fs/cache/Registry.hpp"
 #include "rbac/resolver/vault/all.hpp"
+#include "fuse/Resolver.hpp"
 
 #include <cerrno>
 #include <cstring>
@@ -231,55 +232,27 @@ void readdir(const fuse_req_t req, const fuse_ino_t ino, const size_t size, cons
 }
 
 void lookup(const fuse_req_t req, const fuse_ino_t parent, const char* name) {
-    log::Registry::fuse()->debug("[lookup] Called for parent: {}, name: {}", parent, name);
-    if (!name || strlen(name) == 0) {
-        fuse_reply_err(req, EINVAL);
+    log::Registry::fuse()->error("[lookup] Called for parent: {}, name: {}", parent, name);
+
+    const auto resolved = Resolver::resolve({
+        .caller = "lookup",
+        .fuseReq = req,
+        .parentIno = parent,
+        .childName = name,
+        .action = permission::vault::FilesystemAction::List,
+        .target = resolver::Target::EntryForPath
+    });
+
+    if (!resolved.ok()) {
+        fuse_reply_err(req, resolved.errnum);
         return;
     }
-
-    const fuse_ctx* ctx = fuse_req_ctx(req);
-    uid_t uid = ctx->uid;
-    // gid_t gid = ctx->gid;
-    
-    const auto user = db::query::identities::User::getUserByLinuxUID(uid);
-    if (!user) {
-        log::Registry::fuse()->debug("[lookup] No user found for UID: {}", uid);
-        fuse_reply_err(req, EACCES);
-        return;
-    }
-
-    const auto& cache = runtime::Deps::get().fsCache;
-
-    const auto parentPath = cache->resolvePath(parent);
-    const auto path = parentPath / name;
-    const fuse_ino_t ino = cache->getOrAssignInode(path);
-
-    log::Registry::fuse()->debug("[lookup] name: {}, parentPath: {}, inode: {}, Resolved path: {}", name, parentPath.string(), ino, path.string());
-
-    const auto entry = cache->getEntry(path);
-    if (!entry) {
-        log::Registry::fuse()->debug("[lookup] Entry not found for path: {}", path.string());
-        fuse_reply_err(req, ENOENT);
-        return;
-    }
-
-    if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::List,
-            .entry = entry
-        })) {
-        log::Registry::fuse()->error("[lookup] Access denied for user {} on path {}", user->name, entry->path.string());
-        fuse_reply_err(req, EPERM);
-        return;
-        }
-
-    const auto st = statFromEntry(entry, ino);
 
     fuse_entry_param e{};
-    e.ino = ino;
+    e.ino = *resolved.ino;
     e.attr_timeout = 0.1;
     e.entry_timeout = 0.1;
-    e.attr = st;
+    e.attr = statFromEntry(resolved.entry, *resolved.ino);
 
     fuse_reply_entry(req, &e);
 }

--- a/src/fuse/Bridge.cpp
+++ b/src/fuse/Bridge.cpp
@@ -43,12 +43,8 @@ void getattr(const fuse_req_t req, const fuse_ino_t ino, fuse_file_info* fi) {
         return;
     }
 
-    try {
-        const auto st = statFromEntry(resolved.entry, ino);
-        fuse_reply_attr(req, &st, 0.1); // match attr_timeout from lookup()
-    } catch (const std::exception&) {
-        fuse_reply_err(req, ENOENT);
-    }
+    const auto st = statFromEntry(resolved.entry, ino);
+    fuse_reply_attr(req, &st, 0.1); // match attr_timeout from lookup()
 }
 
 void setattr(const fuse_req_t req, const fuse_ino_t ino,
@@ -81,29 +77,25 @@ void setattr(const fuse_req_t req, const fuse_ino_t ino,
         return;
     }
 
-    try {
-        timespec times[2];
-        if (to_set & FUSE_SET_ATTR_ATIME) times[0] = attr->st_atim;
-        else times[0].tv_nsec = UTIME_OMIT;
-        if (to_set & FUSE_SET_ATTR_MTIME) times[1] = attr->st_mtim;
-        else times[1].tv_nsec = UTIME_OMIT;
+    timespec times[2];
+    if (to_set & FUSE_SET_ATTR_ATIME) times[0] = attr->st_atim;
+    else times[0].tv_nsec = UTIME_OMIT;
+    if (to_set & FUSE_SET_ATTR_MTIME) times[1] = attr->st_mtim;
+    else times[1].tv_nsec = UTIME_OMIT;
 
-        if (::utimensat(AT_FDCWD, resolved.entry->backing_path.c_str(), times, 0) < 0) {
-            fuse_reply_err(req, errno);
-            return;
-        }
-
-        // Re-stat file so kernel gets fresh info
-        struct stat st = {};
-        if (::stat(resolved.entry->backing_path.c_str(), &st) < 0) {
-            fuse_reply_err(req, errno);
-            return;
-        }
-
-        fuse_reply_attr(req, &st, 1.0);
-    } catch (...) {
-        fuse_reply_err(req, EIO);
+    if (::utimensat(AT_FDCWD, resolved.entry->backing_path.c_str(), times, 0) < 0) {
+        fuse_reply_err(req, errno);
+        return;
     }
+
+    // Re-stat file so kernel gets fresh info
+    struct stat st = {};
+    if (::stat(resolved.entry->backing_path.c_str(), &st) < 0) {
+        fuse_reply_err(req, errno);
+        return;
+    }
+
+    fuse_reply_attr(req, &st, 1.0);
 }
 
 void readdir(const fuse_req_t req, const fuse_ino_t ino, const size_t size, const off_t off, fuse_file_info* fi) {
@@ -212,34 +204,34 @@ void create(const fuse_req_t req, const fuse_ino_t parent, const char* name, con
         return;
     }
 
-    try {
-        const auto newEntry = Filesystem::createFile(*resolved.path, getuid(), getgid(), mode);
-        const auto st = statFromEntry(newEntry, *newEntry->inode);
-
-        // open backing file immediately
-        const int fd = ::open(newEntry->backing_path.c_str(), O_CREAT | O_RDWR, mode);
-        if (fd < 0) {
-            fuse_reply_err(req, errno);
-            return;
-        }
-
-        auto* fh = new FileHandle{newEntry->backing_path.string(), fd};
-        fi->fh = reinterpret_cast<uint64_t>(fh);
-
-        fi->direct_io = 1;
-        fi->keep_cache = 0;
-
-        fuse_entry_param e{};
-        e.ino           = *newEntry->inode;
-        e.attr          = st;
-        e.attr_timeout  = 60.0;
-        e.entry_timeout = 60.0;
-
-        fuse_reply_create(req, &e, fi);
-    } catch (const std::exception& ex) {
-        log::Registry::fuse()->error("[create] Exception: {}", ex.what());
-        fuse_reply_err(req, EIO);
+    const auto [err, newEntry] = Filesystem::createFile(*resolved.path, getuid(), getgid(), mode);
+    if (err) {
+        fuse_reply_err(req, err);
+        return;
     }
+
+    const auto st = statFromEntry(newEntry, *newEntry->inode);
+
+    // open backing file immediately
+    const int fd = ::open(newEntry->backing_path.c_str(), O_CREAT | O_RDWR, mode);
+    if (fd < 0) {
+        fuse_reply_err(req, errno);
+        return;
+    }
+
+    auto* fh = new FileHandle{newEntry->backing_path.string(), fd};
+    fi->fh = reinterpret_cast<uint64_t>(fh);
+
+    fi->direct_io = 1;
+    fi->keep_cache = 0;
+
+    fuse_entry_param e{};
+    e.ino           = *newEntry->inode;
+    e.attr          = st;
+    e.attr_timeout  = 60.0;
+    e.entry_timeout = 60.0;
+
+    fuse_reply_create(req, &e, fi);
 }
 
 void open(const fuse_req_t req, const fuse_ino_t ino, fuse_file_info* fi) {
@@ -260,24 +252,19 @@ void open(const fuse_req_t req, const fuse_ino_t ino, fuse_file_info* fi) {
         return;
     }
 
-    try {
-        const int fd = ::open(resolved.entry->backing_path.c_str(), fi->flags, 0644);
-        if (fd < 0) {
-            fuse_reply_err(req, errno);
-            return;
-        }
-
-        auto* fh = new FileHandle{resolved.entry->backing_path.string(), fd};
-        fi->fh = reinterpret_cast<uint64_t>(fh);
-
-        fi->direct_io = 1;
-        fi->keep_cache = 0;
-
-        fuse_reply_open(req, fi);
-    } catch (const std::exception& ex) {
-        log::Registry::fuse()->error("[open] Exception: {}", ex.what());
-        fuse_reply_err(req, EIO);
+    const int fd = ::open(resolved.entry->backing_path.c_str(), fi->flags, 0644);
+    if (fd < 0) {
+        fuse_reply_err(req, errno);
+        return;
     }
+
+    auto* fh = new FileHandle{resolved.entry->backing_path.string(), fd};
+    fi->fh = reinterpret_cast<uint64_t>(fh);
+
+    fi->direct_io = 1;
+    fi->keep_cache = 0;
+
+    fuse_reply_open(req, fi);
 }
 
 void write(const fuse_req_t req, const fuse_ino_t ino, const char* buf,
@@ -356,29 +343,26 @@ void mkdir(const fuse_req_t req, const fuse_ino_t parent, const char* name, cons
         return;
     }
 
-    try {
-        if (std::string_view(name).find('/') != std::string::npos) {
-            fuse_reply_err(req, EINVAL);
-            return;
-        }
-
-        Filesystem::mkdir(*resolved.path, mode);
-
-        const auto finalInode = runtime::Deps::get().fsCache->resolveInode(*resolved.path);
-        const auto finalEntry = runtime::Deps::get().fsCache->getEntry(*resolved.path);
-
-        fuse_entry_param e{};
-        e.ino = finalInode;
-        e.attr_timeout = 1.0;
-        e.entry_timeout = 1.0;
-        e.attr = statFromEntry(finalEntry, finalInode);
-
-        fuse_reply_entry(req, &e);
-
-    } catch (const std::exception& ex) {
-        log::Registry::fuse()->error("[mkdir] Exception: {}", ex.what());
-        fuse_reply_err(req, EIO);
+    if (std::string_view(name).find('/') != std::string::npos) {
+        fuse_reply_err(req, EINVAL);
+        return;
     }
+
+    if (const auto err = Filesystem::mkdir(*resolved.path, mode); err) {
+        fuse_reply_err(req, err);
+        return;
+    }
+
+    const auto finalInode = runtime::Deps::get().fsCache->resolveInode(*resolved.path);
+    const auto finalEntry = runtime::Deps::get().fsCache->getEntry(*resolved.path);
+
+    fuse_entry_param e{};
+    e.ino = finalInode;
+    e.attr_timeout = 1.0;
+    e.entry_timeout = 1.0;
+    e.attr = statFromEntry(finalEntry, finalInode);
+
+    fuse_reply_entry(req, &e);
 }
 
 void rename(const fuse_req_t req, const fuse_ino_t parent, const char* name, const fuse_ino_t newparent, const char* newname, const unsigned int flags) {
@@ -403,20 +387,18 @@ void rename(const fuse_req_t req, const fuse_ino_t parent, const char* name, con
         return;
     }
 
-    try {
-        // Flags handling (RENAME_NOREPLACE = 1, RENAME_EXCHANGE = 2)
-        if ((flags & RENAME_NOREPLACE) && cache->entryExists(toPath)) {
-            fuse_reply_err(req, EEXIST);
-            return;
-        }
-
-        Filesystem::rename(*resolved.path, toPath);
-
-        fuse_reply_err(req, 0);  // Success
-    } catch (const std::exception& ex) {
-        log::Registry::fuse()->error("[rename] Exception: {}", ex.what());
-        fuse_reply_err(req, EIO);
+    // Flags handling (RENAME_NOREPLACE = 1, RENAME_EXCHANGE = 2)
+    if ((flags & RENAME_NOREPLACE) && cache->entryExists(toPath)) {
+        fuse_reply_err(req, EEXIST);
+        return;
     }
+
+    if (const auto err = Filesystem::rename(*resolved.path, toPath); err) {
+        fuse_reply_err(req, err);
+        return;
+    }
+
+    fuse_reply_err(req, 0);  // Success
 }
 
 void forget(const fuse_req_t req, const fuse_ino_t ino, const uint64_t nlookup) {
@@ -478,17 +460,12 @@ void unlink(const fuse_req_t req, const fuse_ino_t parent, const char* name) {
         return;
     }
 
-    try {
-        db::query::fs::File::markFileAsTrashed(resolved.user->id, *resolved.entry->vault_id, resolved.entry->path, true);
+    db::query::fs::File::markFileAsTrashed(resolved.user->id, *resolved.entry->vault_id, resolved.entry->path, true);
 
-        if (::unlink(resolved.entry->backing_path.c_str()) < 0)
-            log::Registry::fuse()->debug("[unlink] Failed to remove backing file: {}: {}", resolved.entry->backing_path.string(), strerror(errno));
+    if (::unlink(resolved.entry->backing_path.c_str()) < 0)
+        log::Registry::fuse()->debug("[unlink] Failed to remove backing file: {}: {}", resolved.entry->backing_path.string(), strerror(errno));
 
-        fuse_reply_err(req, 0);
-    } catch (const std::exception& ex) {
-        log::Registry::fuse()->error("[unlink] Exception: {}", ex.what());
-        fuse_reply_err(req, EIO);
-    }
+    fuse_reply_err(req, 0);
 }
 
 void rmdir(const fuse_req_t req, const fuse_ino_t parent, const char* name) {
@@ -508,17 +485,12 @@ void rmdir(const fuse_req_t req, const fuse_ino_t parent, const char* name) {
         return;
     }
 
-    try {
-        db::query::fs::Directory::deleteEmptyDirectory(resolved.entry->id);
+    db::query::fs::Directory::deleteEmptyDirectory(resolved.entry->id);
 
-        if (::rmdir(resolved.entry->backing_path.c_str()) < 0)
-            log::Registry::fuse()->error("[rmdir] Failed to remove backing directory: {}: {}", resolved.entry->backing_path.string(), strerror(errno));
+    if (::rmdir(resolved.entry->backing_path.c_str()) < 0)
+        log::Registry::fuse()->error("[rmdir] Failed to remove backing directory: {}: {}", resolved.entry->backing_path.string(), strerror(errno));
 
-        fuse_reply_err(req, 0);
-    } catch (const std::exception& ex) {
-        log::Registry::fuse()->error("[rmdir] Exception: {}", ex.what());
-        fuse_reply_err(req, EIO);
-    }
+    fuse_reply_err(req, 0);
 }
 
 void flush(const fuse_req_t req, const fuse_ino_t ino, fuse_file_info* fi) {
@@ -568,18 +540,13 @@ void fsync(const fuse_req_t req, const fuse_ino_t ino, const int datasync, fuse_
         return;
     }
 
-    try {
-        if (const int fd = fi->fh; ::fsync(fd) < 0) {
-            log::Registry::fuse()->error("[fsync] Failed to sync file handle: {}: {}", fd, strerror(errno));
-            fuse_reply_err(req, errno);
-            return;
-        }
-
-        fuse_reply_err(req, 0);
-    } catch (const std::exception& ex) {
-        log::Registry::fuse()->error("[fsync] Exception: {}", ex.what());
-        fuse_reply_err(req, EIO);
+    if (const int fd = fi->fh; ::fsync(fd) < 0) {
+        log::Registry::fuse()->error("[fsync] Failed to sync file handle: {}: {}", fd, strerror(errno));
+        fuse_reply_err(req, errno);
+        return;
     }
+
+    fuse_reply_err(req, 0);
 }
 
 void statfs(const fuse_req_t req, const fuse_ino_t ino) {
@@ -598,20 +565,15 @@ void statfs(const fuse_req_t req, const fuse_ino_t ino) {
         return;
     }
 
-    try {
-        struct statvfs st{};
+    struct statvfs st{};
 
-        if (::statvfs(resolved.entry->backing_path.c_str(), &st) < 0) {
-            log::Registry::fuse()->error("[statfs] Failed to get filesystem stats for: {}: {}", resolved.entry->backing_path.string(), strerror(errno));
-            fuse_reply_err(req, errno);
-            return;
-        }
-
-        fuse_reply_statfs(req, &st);
-    } catch (const std::exception& ex) {
-        log::Registry::fuse()->error("[statfs] Exception: {}", ex.what());
-        fuse_reply_err(req, EIO);
+    if (::statvfs(resolved.entry->backing_path.c_str(), &st) < 0) {
+        log::Registry::fuse()->error("[statfs] Failed to get filesystem stats for: {}: {}", resolved.entry->backing_path.string(), strerror(errno));
+        fuse_reply_err(req, errno);
+        return;
     }
+
+    fuse_reply_statfs(req, &st);
 }
 
 fuse_lowlevel_ops getOperations() {

--- a/src/fuse/Bridge.cpp
+++ b/src/fuse/Bridge.cpp
@@ -1,10 +1,7 @@
 #include "fuse/Bridge.hpp"
 #include "storage/Manager.hpp"
-#include "storage/Engine.hpp"
 #include "identities/User.hpp"
-#include "fs/model/Path.hpp"
 #include "fs/model/Entry.hpp"
-#include "vault/model/Vault.hpp"
 #include "config/Registry.hpp"
 #include "fs/Filesystem.hpp"
 #include "runtime/Deps.hpp"
@@ -13,7 +10,6 @@
 #include "db/query/fs/Directory.hpp"
 #include "log/Registry.hpp"
 #include "fs/cache/Registry.hpp"
-#include "rbac/resolver/vault/all.hpp"
 #include "fuse/Resolver.hpp"
 
 #include <cerrno>
@@ -34,55 +30,21 @@ void getattr(const fuse_req_t req, const fuse_ino_t ino, fuse_file_info* fi) {
     log::Registry::fuse()->debug("[getattr] Called for inode: {}", ino);
     (void)fi;
 
-    const fuse_ctx* ctx = fuse_req_ctx(req);
-    uid_t uid = ctx->uid;
-    // gid_t gid = ctx->gid;
+    const auto resolved = Resolver::resolve({
+        .caller = "getattr",
+        .fuseReq = req,
+        .ino = ino,
+        .action = permission::vault::FilesystemAction::List,
+        .target = resolver::Target::Entry
+    });
 
-    const auto user = db::query::identities::User::getUserByLinuxUID(uid);
-    if (!user) {
-        log::Registry::fuse()->error("[getattr] No user found for UID: {}", uid);
-        fuse_reply_err(req, EACCES);
+    if (!resolved.ok()) {
+        fuse_reply_err(req, resolved.errnum);
         return;
     }
 
     try {
-        const auto& cache = runtime::Deps::get().fsCache;
-        if (ino == FUSE_ROOT_ID) {
-            const auto entry = cache->getEntry(FUSE_ROOT_ID);
-            if (!entry) {
-                log::Registry::fuse()->error("[getattr] No entry found for inode {}, resolved path: /", ino);
-                fuse_reply_err(req, ENOENT);
-                return;
-            }
-
-            struct stat st = statFromEntry(entry, ino);
-            st.st_uid = getuid();  // explicitly set ownership
-            st.st_gid = getgid();
-
-            fuse_reply_attr(req, &st,  0.1);
-            return;
-        }
-
-        const auto entry = cache->getEntry(ino);
-
-        if (!entry) {
-            log::Registry::fuse()->error("[getattr] No entry found for inode {}", ino);
-            fuse_reply_err(req, ENOENT);
-            return;
-        }
-
-        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::List,
-            .entry = entry
-        })) {
-            log::Registry::fuse()->error("[getattr] Access denied for user {} on path {}", user->name, entry->path.string());
-            fuse_reply_err(req, EPERM);
-            return;
-        }
-
-        const auto st = statFromEntry(entry, ino);
-
+        const auto st = statFromEntry(resolved.entry, ino);
         fuse_reply_attr(req, &st, 0.1); // match attr_timeout from lookup()
     } catch (const std::exception&) {
         fuse_reply_err(req, ENOENT);
@@ -92,18 +54,7 @@ void getattr(const fuse_req_t req, const fuse_ino_t ino, fuse_file_info* fi) {
 void setattr(const fuse_req_t req, const fuse_ino_t ino,
                          struct stat* attr, int to_set, fuse_file_info* fi) {
     (void)fi;
-    const fuse_ctx* ctx = fuse_req_ctx(req);
-    const uid_t uid = ctx->uid;
-
-    const auto user = db::query::identities::User::getUserByLinuxUID(uid);
-    if (!user) {
-        log::Registry::fuse()->error("[setattr] No user found for UID: {}", uid);
-        fuse_reply_err(req, EACCES);
-        return;
-    }
-
-    log::Registry::fuse()->debug("[setattr] Called for inode: {}, to_set: {}, uid: {}, gid: {}",
-        ino, to_set, ctx->uid, ctx->gid);
+    log::Registry::fuse()->debug("[setattr] Called for inode: {}, to_set: {}", ino, to_set);
 
     if (to_set & FUSE_SET_ATTR_MODE) {
         log::Registry::fuse()->warn("⚔️ [Vaulthalla] Illegal access: chmod is forbidden beyond the gates!");
@@ -117,38 +68,34 @@ void setattr(const fuse_req_t req, const fuse_ino_t ino,
         return;
     }
 
+    const auto resolved = Resolver::resolve({
+        .caller = "setattr",
+        .fuseReq = req,
+        .ino = ino,
+        .action = permission::vault::FilesystemAction::Upload,
+        .target = resolver::Target::Entry
+    });
+
+    if (!resolved.ok()) {
+        fuse_reply_err(req, resolved.errnum);
+        return;
+    }
+
     try {
-        const auto entry = runtime::Deps::get().fsCache->getEntry(ino);
-        if (!entry) {
-            log::Registry::fuse()->error("[setattr] No entry found for inode {}", ino);
-            fuse_reply_err(req, ENOENT);
-            return;
-        }
-
-        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::Upload,
-            .entry = entry
-        })) {
-            log::Registry::fuse()->warn("[setattr] Access denied for user {} on path {}", user->name, entry->path.string());
-            fuse_reply_err(req, EPERM);
-            return;
-        }
-
         timespec times[2];
         if (to_set & FUSE_SET_ATTR_ATIME) times[0] = attr->st_atim;
         else times[0].tv_nsec = UTIME_OMIT;
         if (to_set & FUSE_SET_ATTR_MTIME) times[1] = attr->st_mtim;
         else times[1].tv_nsec = UTIME_OMIT;
 
-        if (::utimensat(AT_FDCWD, entry->backing_path.c_str(), times, 0) < 0) {
+        if (::utimensat(AT_FDCWD, resolved.entry->backing_path.c_str(), times, 0) < 0) {
             fuse_reply_err(req, errno);
             return;
         }
 
         // Re-stat file so kernel gets fresh info
         struct stat st = {};
-        if (::stat(entry->backing_path.c_str(), &st) < 0) {
+        if (::stat(resolved.entry->backing_path.c_str(), &st) < 0) {
             fuse_reply_err(req, errno);
             return;
         }
@@ -163,34 +110,23 @@ void readdir(const fuse_req_t req, const fuse_ino_t ino, const size_t size, cons
     log::Registry::fuse()->debug("[readdir] Called for inode: {}, size: {}, offset: {}", ino, size, off);
     (void)fi;
 
-    const fuse_ctx* ctx = fuse_req_ctx(req);
-    const uid_t uid = ctx->uid;
+    const std::optional<permission::vault::FilesystemAction> action = ino == FUSE_ROOT_ID ?
+        std::nullopt : std::make_optional(permission::vault::FilesystemAction::List);
 
-    const auto entry = runtime::Deps::get().fsCache->getEntry(ino);
-    if (!entry) {
-        log::Registry::fuse()->error("[readdir] No entry found for inode {}", ino);
-        fuse_reply_err(req, ENOENT);
+    const auto resolved = Resolver::resolve({
+        .caller = "readdir",
+        .fuseReq = req,
+        .ino = ino,
+        .action = action,
+        .target = resolver::Target::Entry
+    });
+
+    if (!resolved.ok()) {
+        fuse_reply_err(req, resolved.errnum);
         return;
     }
 
-    const auto user = db::query::identities::User::getUserByLinuxUID(uid);
-    if (!user) {
-        log::Registry::fuse()->error("[readdir] No user found for UID: {}", uid);
-        fuse_reply_err(req, EACCES);
-        return;
-    }
-
-    if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::List,
-            .entry = entry
-        })) {
-        log::Registry::fuse()->error("[readdir] Access denied for user {} on path {}", user->name, entry->path.string());
-        fuse_reply_err(req, EPERM);
-        return;
-        }
-
-    const auto entries = runtime::Deps::get().fsCache->listDir(entry->id, false);
+    const auto entries = runtime::Deps::get().fsCache->listDir(resolved.entry->id, false);
 
     std::vector<char> buf(size);
     size_t buf_used = 0;
@@ -207,24 +143,20 @@ void readdir(const fuse_req_t req, const fuse_ino_t ino, const size_t size, cons
     off_t current_off = 0;
 
     if (off <= current_off++) {
-        struct stat dot;
+        struct stat dot{};
         dot.st_mode = S_IFDIR;
         if (!add_entry(".", dot, current_off)) goto reply;
     }
 
     if (off <= current_off++) {
-        struct stat dotdot;
+        struct stat dotdot{};
         dotdot.st_mode = S_IFDIR;
         if (!add_entry("..", dotdot, current_off)) goto reply;
     }
 
     for (size_t i = 0; i < entries.size(); ++i, ++current_off) {
         if (off > current_off) continue;
-
-        const auto& e = entries[i];
-        const auto st = statFromEntry(e, ino);
-
-        if (!add_entry(e->name, st, current_off + 1)) break;
+        if (!add_entry(entries[i]->name, statFromEntry(entries[i], ino), current_off + 1)) break;
     }
 
     reply:
@@ -261,50 +193,28 @@ void create(const fuse_req_t req, const fuse_ino_t parent, const char* name, con
     log::Registry::fuse()->debug("[create] Called for parent: {}, name: {}, mode: {}",
         parent, name, mode);
 
-    const fuse_ctx* ctx = fuse_req_ctx(req);
-    uid_t uid = ctx->uid;
+    const auto resolved = Resolver::resolve({
+        .caller = "create",
+        .fuseReq = req,
+        .parentIno = parent,
+        .childName = name,
+        .action = permission::vault::FilesystemAction::Upload,
+        .target = resolver::Target::Path
+    });
 
-    if (!name || strlen(name) == 0) {
-        fuse_reply_err(req, EINVAL);
+    if (!resolved.ok()) {
+        fuse_reply_err(req, resolved.errnum);
+        return;
+    }
+
+    if (runtime::Deps::get().fsCache->entryExists(*resolved.path)) {
+        fuse_reply_err(req, EEXIST);
         return;
     }
 
     try {
-        const auto parentPath = runtime::Deps::get().fsCache->resolvePath(parent);
-        const auto fullPath = parentPath / name;
-
-        const auto engine = runtime::Deps::get().storageManager->resolveStorageEngine(fullPath);
-        if (!engine) {
-            log::Registry::fuse()->error("[create] No storage engine found for path: {}", fullPath.string());
-            fuse_reply_err(req, EIO);
-            return;
-        }
-
-        const auto vaultPath = engine->paths->absRelToAbsRel(fullPath, PathType::FUSE_ROOT, PathType::VAULT_ROOT);
-        const auto user = db::query::identities::User::getUserByLinuxUID(uid);
-        if (!user) {
-            log::Registry::fuse()->error("[create] No user found for UID: {}", uid);
-            fuse_reply_err(req, EACCES);
-            return;
-        }
-
-        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::Upload,
-            .path = vaultPath,
-        })) {
-            log::Registry::fuse()->error("[create] Access denied for user {} on path {}", user->name, vaultPath.string());
-            fuse_reply_err(req, EPERM);
-            return;
-        }
-
-        if (runtime::Deps::get().fsCache->entryExists(fullPath)) {
-            fuse_reply_err(req, EEXIST);
-            return;
-        }
-
-        const auto newEntry = Filesystem::createFile(fullPath, getuid(), getgid(), mode);
-        const auto st       = statFromEntry(newEntry, *newEntry->inode);
+        const auto newEntry = Filesystem::createFile(*resolved.path, getuid(), getgid(), mode);
+        const auto st = statFromEntry(newEntry, *newEntry->inode);
 
         // open backing file immediately
         const int fd = ::open(newEntry->backing_path.c_str(), O_CREAT | O_RDWR, mode);
@@ -337,42 +247,27 @@ void open(const fuse_req_t req, const fuse_ino_t ino, fuse_file_info* fi) {
 
     runtime::Deps::get().storageManager->registerOpenHandle(ino);
 
-    const fuse_ctx* ctx = fuse_req_ctx(req);
-    uid_t uid = ctx->uid;
-    // gid_t gid = ctx->gid;
+    const auto resolved = Resolver::resolve({
+        .caller = "open",
+        .fuseReq = req,
+        .ino = ino,
+        .action = permission::vault::FilesystemAction::Download,
+        .target = resolver::Target::Entry
+    });
 
-    const auto user = db::query::identities::User::getUserByLinuxUID(uid);
-    if (!user) {
-        log::Registry::fuse()->error("[open] No user found for UID: {}", uid);
-        fuse_reply_err(req, EACCES);
+    if (!resolved.ok()) {
+        fuse_reply_err(req, resolved.errnum);
         return;
     }
 
     try {
-        const auto entry = runtime::Deps::get().fsCache->getEntry(ino);
-        if (!entry) {
-            log::Registry::fuse()->error("[open] No entry found for inode {}", ino);
-            fuse_reply_err(req, ENOENT);
-            return;
-        }
-
-        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::Download,
-            .entry = entry
-        })) {
-            log::Registry::fuse()->error("[open] Access denied for user {} on path {}", user->name, entry->path.string());
-            fuse_reply_err(req, EPERM);
-            return;
-        }
-
-        const int fd = ::open(entry->backing_path.c_str(), fi->flags, 0644);
+        const int fd = ::open(resolved.entry->backing_path.c_str(), fi->flags, 0644);
         if (fd < 0) {
             fuse_reply_err(req, errno);
             return;
         }
 
-        auto* fh = new FileHandle{entry->backing_path.string(), fd};
+        auto* fh = new FileHandle{resolved.entry->backing_path.string(), fd};
         fi->fh = reinterpret_cast<uint64_t>(fh);
 
         fi->direct_io = 1;
@@ -390,9 +285,6 @@ void write(const fuse_req_t req, const fuse_ino_t ino, const char* buf,
     log::Registry::fuse()->debug("[write] Called for inode: {}, size: {}, offset: {}, file handle: {}",
         ino, size, off, fi->fh);
 
-    const fuse_ctx* ctx = fuse_req_ctx(req);
-    uid_t uid = ctx->uid;
-
     const auto* fh = reinterpret_cast<FileHandle*>(fi->fh);
     (void)ino; // unused
 
@@ -401,35 +293,23 @@ void write(const fuse_req_t req, const fuse_ino_t ino, const char* buf,
     const ssize_t res = ::pwrite(fh->fd, buf, size, off);
     if (res < 0) fuse_reply_err(req, errno);
 
-    const auto user = db::query::identities::User::getUserByLinuxUID(uid);
-    if (!user) {
-        log::Registry::fuse()->error("[write] No user found for UID: {}", uid);
-        fuse_reply_err(req, EACCES);
+    const auto resolved = Resolver::resolve({
+        .caller = "write",
+        .fuseReq = req,
+        .ino = ino,
+        .action = permission::vault::FilesystemAction::Upload,
+        .target = resolver::Target::Entry
+    });
+
+    if (!resolved.ok()) {
+        fuse_reply_err(req, resolved.errnum);
         return;
     }
 
-    const auto entry = runtime::Deps::get().fsCache->getEntry(ino);
-    if (!entry) {
-        log::Registry::fuse()->error("[write] No entry found for inode {}", ino);
-        fuse_reply_err(req, ENOENT);
-        return;
-    }
-
-    if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::Upload,
-            .entry = entry
-        })) {
-        log::Registry::fuse()->error("[write] Access denied for user {} on path {}", user->name, entry->path.string());
-        fuse_reply_err(req, EPERM);
-        return;
-        }
-
-    entry->size_bytes = std::filesystem::file_size(entry->backing_path);
-    runtime::Deps::get().fsCache->updateEntry(entry);
+    resolved.entry->size_bytes = std::filesystem::file_size(resolved.entry->backing_path);
+    runtime::Deps::get().fsCache->updateEntry(resolved.entry);
 
     fuse_lowlevel_notify_inval_inode(runtime::Deps::get().fuseSession, ino, 0, 0);
-
     fuse_reply_write(req, res);
 }
 
@@ -437,34 +317,20 @@ void read(const fuse_req_t req, const fuse_ino_t ino, const size_t size, const o
     log::Registry::fuse()->debug("[read] Called for inode: {}, size: {}, offset: {}, file handle: {}",
         ino, size, off, fi->fh);
 
-    const fuse_ctx* ctx = fuse_req_ctx(req);
-    uid_t uid = ctx->uid;
-
     const auto* fh = reinterpret_cast<FileHandle*>(fi->fh);
 
-    const auto entry = runtime::Deps::get().fsCache->getEntry(ino);
-    if (!entry) {
-        log::Registry::fuse()->error("[read] No entry found for inode {}", ino);
-        fuse_reply_err(req, ENOENT);
+    const auto resolved = Resolver::resolve({
+        .caller = "read",
+        .fuseReq = req,
+        .ino = ino,
+        .action = permission::vault::FilesystemAction::Download,
+        .target = resolver::Target::Entry
+    });
+
+    if (!resolved.ok()) {
+        fuse_reply_err(req, resolved.errnum);
         return;
     }
-
-    const auto user = db::query::identities::User::getUserByLinuxUID(uid);
-    if (!user) {
-        log::Registry::fuse()->error("[read] No user found for UID: {}", uid);
-        fuse_reply_err(req, EACCES);
-        return;
-    }
-
-    if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::Download,
-            .entry = entry
-        })) {
-        log::Registry::fuse()->error("[read] Access denied for user {} on path {}", user->name, entry->path.string());
-        fuse_reply_err(req, EPERM);
-        return;
-        }
 
     std::vector<char> buffer(size);
     const ssize_t res = ::pread(fh->fd, buffer.data(), size, off);
@@ -476,13 +342,17 @@ void read(const fuse_req_t req, const fuse_ino_t ino, const size_t size, const o
 void mkdir(const fuse_req_t req, const fuse_ino_t parent, const char* name, const mode_t mode) {
     log::Registry::fuse()->debug("[mkdir] Called for parent: {}, name: {}, mode: {}", parent, name, mode);
 
-    const fuse_ctx* ctx = fuse_req_ctx(req);
-    uid_t uid = ctx->uid;
+    const auto resolved = Resolver::resolve({
+        .caller = "mkdir",
+        .fuseReq = req,
+        .parentIno = parent,
+        .childName = name,
+        .action = permission::vault::FilesystemAction::Touch,
+        .target = resolver::Target::Path
+    });
 
-    const auto user = db::query::identities::User::getUserByLinuxUID(uid);
-    if (!user) {
-        log::Registry::fuse()->error("[mkdir] No user found for UID: {}", uid);
-        fuse_reply_err(req, EACCES);
+    if (!resolved.ok()) {
+        fuse_reply_err(req, resolved.errnum);
         return;
     }
 
@@ -492,46 +362,10 @@ void mkdir(const fuse_req_t req, const fuse_ino_t parent, const char* name, cons
             return;
         }
 
-        const auto& cache = runtime::Deps::get().fsCache;
+        Filesystem::mkdir(*resolved.path, mode);
 
-        const auto parentPath = cache->resolvePath(parent);
-        if (parentPath.empty()) {
-            fuse_reply_err(req, ENOENT);
-            return;
-        }
-
-        const std::filesystem::path fullPath = parentPath / name;
-
-        const auto engine = runtime::Deps::get().storageManager->resolveStorageEngine(fullPath);
-        if (!engine) {
-            log::Registry::fuse()->error("[mkdir] No storage engine found for path: {}", fullPath.string());
-            fuse_reply_err(req, EIO);
-            return;
-        }
-
-        const auto vaultPath = engine->paths->absRelToAbsRel(fullPath, PathType::FUSE_ROOT, PathType::VAULT_ROOT);
-        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::Touch,
-            .path = vaultPath,
-        })) {
-            log::Registry::fuse()->error("[mkdir] Access denied for user {} on path {}", user->name, vaultPath.string());
-            fuse_reply_err(req, EPERM);
-            return;
-        }
-
-        try {
-            Filesystem::mkdir(fullPath, mode);
-        } catch (const std::filesystem::filesystem_error& fsErr) {
-            log::Registry::fuse()->error("[mkdir] Failed to create directory: {} → {}: {}",
-                parentPath.string(), name, fsErr.what());
-            fuse_reply_err(req, EIO);
-            return;
-        }
-
-        // Final directory (last one created) = fullPath
-        const auto finalInode = cache->resolveInode(fullPath);
-        const auto finalEntry = cache->getEntry(fullPath);
+        const auto finalInode = runtime::Deps::get().fsCache->resolveInode(*resolved.path);
+        const auto finalEntry = runtime::Deps::get().fsCache->getEntry(*resolved.path);
 
         fuse_entry_param e{};
         e.ino = finalInode;
@@ -551,52 +385,32 @@ void rename(const fuse_req_t req, const fuse_ino_t parent, const char* name, con
     log::Registry::fuse()->debug("[rename] Called for parent: {}, name: {}, newparent: {}, newname: {}, flags: {}",
                                parent, name, newparent, newname, flags);
 
-    const fuse_ctx* ctx = fuse_req_ctx(req);
-    uid_t uid = ctx->uid;
-
     const auto& cache = runtime::Deps::get().fsCache;
 
-    try {
-        const auto fromPath = cache->resolvePath(parent) / name;
-        const auto toPath = cache->resolvePath(newparent) / newname;
+    const auto toPath = cache->resolvePath(newparent) / newname;
 
+    const auto resolved = Resolver::resolve({
+        .caller = "rename",
+        .fuseReq = req,
+        .parentIno = parent,
+        .childName = name,
+        .action = permission::vault::FilesystemAction::Rename,
+        .target = resolver::Target::EntryForPath
+    });
+
+    if (!resolved.ok()) {
+        fuse_reply_err(req, resolved.errnum);
+        return;
+    }
+
+    try {
         // Flags handling (RENAME_NOREPLACE = 1, RENAME_EXCHANGE = 2)
         if ((flags & RENAME_NOREPLACE) && cache->entryExists(toPath)) {
             fuse_reply_err(req, EEXIST);
             return;
         }
 
-        const auto entry = cache->getEntry(fromPath);
-        if (!entry) {
-            fuse_reply_err(req, ENOENT);
-            return;
-        }
-
-        const auto user = db::query::identities::User::getUserByLinuxUID(uid);
-        if (!user) {
-            log::Registry::fuse()->error("[rename] No user found for UID: {}", uid);
-            fuse_reply_err(req, EACCES);
-            return;
-        }
-
-        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::Rename,
-            .entry = entry
-        })) {
-            log::Registry::fuse()->error("[rename] Access denied for user {} on path {}", user->name, entry->path.string());
-            fuse_reply_err(req, EPERM);
-            return;
-        }
-
-        try {
-            Filesystem::rename(fromPath, toPath);
-        } catch (const std::filesystem::filesystem_error& fsErr) {
-            log::Registry::fuse()->error("[rename] Failed to rename: {} → {}: {}",
-                fromPath.string(), toPath.string(), fsErr.what());
-            fuse_reply_err(req, EIO);
-            return;
-        }
+        Filesystem::rename(*resolved.path, toPath);
 
         fuse_reply_err(req, 0);  // Success
     } catch (const std::exception& ex) {
@@ -621,106 +435,54 @@ void forget(const fuse_req_t req, const fuse_ino_t ino, const uint64_t nlookup) 
 void access(const fuse_req_t req, const fuse_ino_t ino, const int mask) {
     log::Registry::fuse()->debug("[access] Called for inode: {}, mask: {}", ino, mask);
 
-    const fuse_ctx* ctx = fuse_req_ctx(req);
-    uid_t uid = ctx->uid;
+    std::vector<rbac::permission::vault::FilesystemAction> requiredPermissions;
+    if (mask & W_OK) requiredPermissions.push_back(permission::vault::FilesystemAction::Upload);
+    if (mask & R_OK) requiredPermissions.push_back(permission::vault::FilesystemAction::Download);
+    if (ino != FUSE_ROOT_ID && mask & X_OK) requiredPermissions.push_back(permission::vault::FilesystemAction::List);
 
-    const auto entry = runtime::Deps::get().fsCache->getEntry(ino);
-    if (!entry) {
-        log::Registry::fuse()->error("[access] No entry found for inode {}", ino);
-        fuse_reply_err(req, ENOENT);
+    const auto resolved = Resolver::resolve({
+        .caller = "access",
+        .fuseReq = req,
+        .ino = ino,
+        .actions = requiredPermissions,
+        .target = resolver::Target::Entry
+    });
+
+    if (!resolved.ok()) {
+        fuse_reply_err(req, resolved.errnum);
         return;
     }
 
-    const auto user = db::query::identities::User::getUserByLinuxUID(uid);
-    if (!user) {
-        log::Registry::fuse()->error("[access] No user found for UID: {}", uid);
-        fuse_reply_err(req, EACCES);
-        return;
-    }
-
-    if (entry->vault_id) {
-        bool allowed = true;
-
-        if ((mask & R_OK) && !rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::Download,
-            .entry = entry
-        })) allowed = false;
-
-        if ((mask & W_OK) && !rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::Upload,
-            .entry = entry
-        })) allowed = false;
-
-        if ((mask & X_OK) && !rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::List,
-            .entry = entry
-        })) allowed = false;
-
-        if (!allowed) {
-            log::Registry::fuse()->warn("[access] Access denied for user {} on path {}, mask: {}",
-                user->name, entry->path.string(), mask);
-            fuse_reply_err(req, EACCES);
-            return;
-        }
-    }
-
-    fuse_reply_err(req, 0); // Access checks are not implemented, always allow
+    fuse_reply_err(req, 0);
 }
 
 void unlink(const fuse_req_t req, const fuse_ino_t parent, const char* name) {
-    const fuse_ctx *ctx = fuse_req_ctx(req);
-    const uid_t uid = ctx->uid;
-    // const gid_t gid = ctx->gid;
-
     log::Registry::fuse()->debug("[unlink] Called for parent: {}, name: {}", parent, name);
 
-    if (!name || strlen(name) == 0) {
-        fuse_reply_err(req, EINVAL);
+    const auto resolved = Resolver::resolve({
+        .caller = "unlink",
+        .fuseReq = req,
+        .parentIno = parent,
+        .childName = name,
+        .action = permission::vault::FilesystemAction::Delete,
+        .target = resolver::Target::EntryForPath
+    });
+
+    if (!resolved.ok()) {
+        fuse_reply_err(req, resolved.errnum);
+        return;
+    }
+
+    if (resolved.entry->isDirectory()) {
+        fuse_reply_err(req, EISDIR);
         return;
     }
 
     try {
-        const auto& cache = runtime::Deps::get().fsCache;
+        db::query::fs::File::markFileAsTrashed(resolved.user->id, *resolved.entry->vault_id, resolved.entry->path, true);
 
-        const auto parentPath = cache->resolvePath(parent);
-        const auto fullPath   = parentPath / name;
-
-        if (!cache->entryExists(fullPath)) {
-            log::Registry::fuse()->debug("[unlink] Entry does not exist for path: {}", fullPath.string());
-            fuse_reply_err(req, ENOENT);
-            return;
-        }
-
-        const auto file = cache->getEntry(fullPath);
-        if (!file || file->isDirectory()) {
-            fuse_reply_err(req, EISDIR);
-            return;
-        }
-
-        const auto user = db::query::identities::User::getUserByLinuxUID(uid);
-        if (!user) {
-            log::Registry::fuse()->error("[unlink] No user found for UID: {}", uid);
-            fuse_reply_err(req, EACCES);
-            return;
-        }
-
-        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::Delete,
-            .entry = file
-        })) {
-            log::Registry::fuse()->warn("[unlink] Access denied for user {} on path {}", user->name, file->path.string());
-            fuse_reply_err(req, EACCES);
-            return;
-        }
-
-        db::query::fs::File::markFileAsTrashed(user->id, *file->vault_id, file->path, true);
-
-        if (::unlink(file->backing_path.c_str()) < 0)
-            log::Registry::fuse()->debug("[unlink] Failed to remove backing file: {}: {}", file->backing_path.string(), strerror(errno));
+        if (::unlink(resolved.entry->backing_path.c_str()) < 0)
+            log::Registry::fuse()->debug("[unlink] Failed to remove backing file: {}: {}", resolved.entry->backing_path.string(), strerror(errno));
 
         fuse_reply_err(req, 0);
     } catch (const std::exception& ex) {
@@ -730,60 +492,27 @@ void unlink(const fuse_req_t req, const fuse_ino_t parent, const char* name) {
 }
 
 void rmdir(const fuse_req_t req, const fuse_ino_t parent, const char* name) {
-    const fuse_ctx *ctx = fuse_req_ctx(req);
-    const uid_t uid = ctx->uid;
-    // const gid_t gid = ctx->gid;
-
     log::Registry::fuse()->debug("[rmdir] Called for parent: {}, name: {}", parent, name);
 
-    if (!name || strlen(name) == 0) {
-        fuse_reply_err(req, EINVAL);
+    const auto resolved = Resolver::resolve({
+        .caller = "rmdir",
+        .fuseReq = req,
+        .parentIno = parent,
+        .childName = name,
+        .action = permission::vault::FilesystemAction::Delete,
+        .target = resolver::Target::EntryForPath
+    });
+
+    if (!resolved.ok()) {
+        fuse_reply_err(req, resolved.errnum);
         return;
     }
 
     try {
-        const auto& cache = runtime::Deps::get().fsCache;
+        db::query::fs::Directory::deleteEmptyDirectory(resolved.entry->id);
 
-        const auto parentPath = cache->resolvePath(parent);
-        const auto fullPath   = parentPath / name;
-
-        if (!cache->entryExists(fullPath)) {
-            fuse_reply_err(req, ENOENT);
-            return;
-        }
-
-        const auto entry = cache->getEntry(fullPath);
-        if (!entry || !entry->isDirectory()) {
-            fuse_reply_err(req, ENOTDIR);
-            return;
-        }
-
-        if (!db::query::fs::Directory::isDirectoryEmpty(entry->id)) {
-            fuse_reply_err(req, ENOTEMPTY);
-            return;
-        }
-
-        const auto user = db::query::identities::User::getUserByLinuxUID(uid);
-        if (!user) {
-            log::Registry::fuse()->error("[rmdir] No user found for UID: {}", uid);
-            fuse_reply_err(req, EACCES);
-            return;
-        }
-
-        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::Delete,
-            .entry = entry
-        })) {
-            log::Registry::fuse()->warn("[rmdir] Access denied for user {} on path {}", user->name, entry->path.string());
-            fuse_reply_err(req, EACCES);
-            return;
-        }
-
-        db::query::fs::Directory::deleteEmptyDirectory(entry->id);
-
-        if (::rmdir(entry->backing_path.c_str()) < 0)
-            log::Registry::fuse()->debug("[rmdir] Failed to remove backing directory: {}: {}", entry->backing_path.string(), strerror(errno));
+        if (::rmdir(resolved.entry->backing_path.c_str()) < 0)
+            log::Registry::fuse()->error("[rmdir] Failed to remove backing directory: {}: {}", resolved.entry->backing_path.string(), strerror(errno));
 
         fuse_reply_err(req, 0);
     } catch (const std::exception& ex) {
@@ -824,35 +553,20 @@ void release(const fuse_req_t req, const fuse_ino_t ino, fuse_file_info* fi) {
 
 void fsync(const fuse_req_t req, const fuse_ino_t ino, const int datasync, fuse_file_info* fi) {
     log::Registry::fuse()->debug("[fsync] Called for inode: {}, file handle: {}, isdatasync: {}", ino, fi->fh, datasync);
-
-    const fuse_ctx* ctx = fuse_req_ctx(req);
-    uid_t uid = ctx->uid;
-
     (void) datasync;
 
-    const auto user = db::query::identities::User::getUserByLinuxUID(uid);
-    if (!user) {
-        log::Registry::fuse()->error("[fsync] No user found for UID: {}", uid);
-        fuse_reply_err(req, EACCES);
+    const auto resolved = Resolver::resolve({
+        .caller = "fsync",
+        .fuseReq = req,
+        .ino = ino,
+        .action = permission::vault::FilesystemAction::Upload,
+        .target = resolver::Target::Entry
+    });
+
+    if (!resolved.ok()) {
+        fuse_reply_err(req, resolved.errnum);
         return;
     }
-
-    const auto entry = runtime::Deps::get().fsCache->getEntry(ino);
-    if (!entry) {
-        log::Registry::fuse()->error("[fsync] No entry found for inode {}", ino);
-        fuse_reply_err(req, ENOENT);
-        return;
-    }
-
-    if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::Upload,
-            .entry = entry
-        })) {
-        log::Registry::fuse()->warn("[fsync] Access denied for user {} on path {}", user->name, entry->path.string());
-        fuse_reply_err(req, EACCES);
-        return;
-        }
 
     try {
         if (const int fd = fi->fh; ::fsync(fd) < 0) {
@@ -871,37 +585,24 @@ void fsync(const fuse_req_t req, const fuse_ino_t ino, const int datasync, fuse_
 void statfs(const fuse_req_t req, const fuse_ino_t ino) {
     log::Registry::fuse()->debug("[statfs] Called for inode: {}", ino);
 
-    const fuse_ctx* ctx = fuse_req_ctx(req);
-    uid_t uid = ctx->uid;
+    const auto resolved = Resolver::resolve({
+        .caller = "statfs",
+        .fuseReq = req,
+        .ino = ino,
+        .action = permission::vault::FilesystemAction::Download,
+        .target = resolver::Target::Entry
+    });
+
+    if (!resolved.ok()) {
+        fuse_reply_err(req, resolved.errnum);
+        return;
+    }
 
     try {
         struct statvfs st{};
-        const auto entry = runtime::Deps::get().fsCache->getEntry(ino);
-        if (!entry) {
-            log::Registry::fuse()->error("[statfs] No entry found for inode {}", ino);
-            fuse_reply_err(req, ENOENT);
-            return;
-        }
 
-        const auto user = db::query::identities::User::getUserByLinuxUID(uid);
-        if (!user) {
-            log::Registry::fuse()->error("[statfs] No user found for UID: {}", uid);
-            fuse_reply_err(req, EACCES);
-            return;
-        }
-
-        if (!rbac::resolver::Vault::has<permission::vault::FilesystemAction>({
-            .user = user,
-            .permission = permission::vault::FilesystemAction::Download,
-            .entry = entry
-        })) {
-            log::Registry::fuse()->warn("[statfs] Access denied for user {} on path {}", user->name, entry->path.string());
-            fuse_reply_err(req, EACCES);
-            return;
-        }
-
-        if (::statvfs(entry->backing_path.c_str(), &st) < 0) {
-            log::Registry::fuse()->error("[statfs] Failed to get filesystem stats for: {}: {}", entry->backing_path.string(), strerror(errno));
+        if (::statvfs(resolved.entry->backing_path.c_str(), &st) < 0) {
+            log::Registry::fuse()->error("[statfs] Failed to get filesystem stats for: {}: {}", resolved.entry->backing_path.string(), strerror(errno));
             fuse_reply_err(req, errno);
             return;
         }

--- a/src/fuse/Reply.cpp
+++ b/src/fuse/Reply.cpp
@@ -1,0 +1,62 @@
+#include "fuse/Reply.hpp"
+#include "log/Registry.hpp"
+
+#include <cerrno>
+
+namespace vh::fuse {
+    int Reply::err(fuse_req_t req, const int errnum) {
+        fuse_reply_err(req, errnum);
+        return 0;
+    }
+
+    bool Reply::failIfNotOk(fuse_req_t req,
+                            const std::string_view caller,
+                            const resolver::Resolved& resolved) {
+        if (resolved.ok()) return false;
+
+        log::Registry::fuse()->error(
+            "[{}] Resolver failed: status={}, errno={}",
+            caller,
+            static_cast<int>(resolved.status),
+            resolved.errnum
+        );
+
+        fuse_reply_err(req, resolved.errnum ? resolved.errnum : EIO);
+        return true;
+    }
+
+    int Reply::entry(fuse_req_t req, const fuse_entry_param& entry) {
+        fuse_reply_entry(req, &entry);
+        return 0;
+    }
+
+    int Reply::attr(fuse_req_t req, const struct stat& stbuf, const double timeout) {
+        fuse_reply_attr(req, &stbuf, timeout);
+        return 0;
+    }
+
+    int Reply::open(fuse_req_t req, fuse_file_info& fi) {
+        fuse_reply_open(req, &fi);
+        return 0;
+    }
+
+    int Reply::buf(fuse_req_t req, const char* data, const size_t size) {
+        fuse_reply_buf(req, data, size);
+        return 0;
+    }
+
+    int Reply::write(fuse_req_t req, const size_t bytes) {
+        fuse_reply_write(req, bytes);
+        return 0;
+    }
+
+    int Reply::none(fuse_req_t req) {
+        fuse_reply_none(req);
+        return 0;
+    }
+
+    int Reply::invalid(fuse_req_t req) { return err(req, EINVAL); }
+    int Reply::access(fuse_req_t req)  { return err(req, EACCES); }
+    int Reply::noent(fuse_req_t req)   { return err(req, ENOENT); }
+    int Reply::io(fuse_req_t req)      { return err(req, EIO); }
+}

--- a/src/fuse/Resolver.cpp
+++ b/src/fuse/Resolver.cpp
@@ -26,14 +26,27 @@ namespace vh::fuse {
         constexpr std::array functions{
             resolveIdentity,
             resolveEntry,
-            resolveEngine,
+            resolveParentEntry,
             resolvePath,
+            resolveEntryForPath,
+            resolveEngine,
             enforcePermissions
         };
 
-        for (const auto &func: functions)
-            if (!func(req, res) || !res.ok())
+        for (const auto &func: functions) {
+            if (!func(req, res)) {
+                if (res.ok()) res.setStatus(Status::InternalError, EIO);
                 break;
+            }
+
+            if (!res.ok()) break;
+        }
+
+        if (!res.ino && (res.entry || res.path)) {
+            if (res.path) res.ino = runtime::Deps::get().fsCache->getOrAssignInode(*res.path);
+            if (!res.ino && res.entry && res.entry->inode) res.ino = res.entry->inode;
+            if (!res.ino) res.setStatus(Status::MissingIno, EINVAL);
+        }
 
         return res;
     }
@@ -51,11 +64,30 @@ namespace vh::fuse {
         out.user = db::query::identities::User::getUserByLinuxUID(uid);
         if (!out.user) {
             log::Registry::fuse()->error("[{}] No user found for UID {}", req.caller, uid);
-            out.status = Status::MissingUser;
+            out.setStatus(Status::MissingUser, EACCES);
             return false;
         }
 
         out.group = db::query::identities::Group::getGroupByLinuxGID(gid);
+
+        return true;
+    }
+
+    bool Resolver::resolveEntry(const resolver::Request &req, resolver::Resolved &out) {
+        if (resolver::hasFlag(req.target, Target::Entry)) {
+            if (!req.ino) {
+                log::Registry::fuse()->debug("[{}] Request target includes Ino but no inode provided", req.caller);
+                out.setStatus(Status::MissingIno, EINVAL);
+                return false;
+            }
+
+            out.entry = runtime::Deps::get().fsCache->getEntry(*req.ino);
+            if (!out.entry) {
+                log::Registry::fuse()->debug("[{}] Failed to resolve entry", req.caller);
+                out.setStatus(Status::MissingEntry, ENOENT);
+                return false;
+            }
+        }
 
         return true;
     }
@@ -65,13 +97,13 @@ namespace vh::fuse {
             if (!req.parentIno) {
                 log::Registry::fuse()->debug("[{}] Request target includes ParentEntry but no parent inode provided",
                                              req.caller);
-                out.status = Status::MissingParentIno;
+                out.setStatus(Status::MissingParentIno, EINVAL);
                 return false;
             }
 
             out.parentEntry = runtime::Deps::get().fsCache->getEntry(*req.parentIno);
             if (!out.parentEntry) {
-                log::Registry::fuse()->error("[{}] Failed to resolve parent entry", req.caller);
+                log::Registry::fuse()->debug("[{}] Failed to resolve parent entry", req.caller);
                 out.setStatus(Status::MissingParentEntry, ENOENT);
                 return false;
             }
@@ -80,21 +112,8 @@ namespace vh::fuse {
         return true;
     }
 
-    bool Resolver::resolveEntry(const resolver::Request &req, resolver::Resolved &out) {
-        if (resolver::hasFlag(req.target, Target::Entry)) {
-            if (!req.ino) {
-                log::Registry::fuse()->debug("[{}] Request target includes Ino but no inode provided", req.caller);
-                out.status = Status::MissingIno;
-                return false;
-            }
-
-            out.entry = runtime::Deps::get().fsCache->getEntry(*req.ino);
-            if (!out.entry) {
-                log::Registry::fuse()->error("[{}] Failed to resolve entry", req.caller);
-                out.setStatus(Status::MissingEntry, ENOENT);
-                return false;
-            }
-        } else if (resolver::hasFlag(req.target, Target::Path) || resolver::hasFlag(req.target, Target::EntryForPath)) {
+    bool Resolver::resolvePath(const resolver::Request &req, resolver::Resolved &out) {
+        if (resolver::hasFlag(req.target, Target::Path) || resolver::hasFlag(req.target, Target::EntryForPath)) {
             if (!out.parentEntry) {
                 log::Registry::fuse()->error("[{}] Cannot resolve path without parent entry", req.caller);
                 out.setStatus(Status::MissingParentEntry, ENOENT);
@@ -102,56 +121,28 @@ namespace vh::fuse {
             }
 
             if (!req.childName) {
-                log::Registry::fuse()->debug("[{}] Request target includes Child but no child name provided", req.caller);
-                out.setStatus(Status::MissingChildName, ENOENT);
-                return false;
-            }
-
-            out.path = out.parentEntry->path / *req.childName;
-            out.fusePath = out.engine->paths->absRelToAbsRel(*out.path, fs::model::PathType::VAULT_ROOT,
-                                                                 fs::model::PathType::FUSE_ROOT);
-
-            if (resolver::hasFlag(req.target, Target::EntryForPath)) {
-                out.entry = runtime::Deps::get().fsCache->getEntry(*out.fusePath);
-                if (!out.entry) {
-                    log::Registry::fuse()->error("[{}] Failed to resolve entry for path {}", req.caller, out.fusePath->string());
-                    out.setStatus(Status::MissingEntry, ENOENT);
-                    return false;
-                }
-            } else out.ino = runtime::Deps::get().fsCache->getOrAssignInode(*out.fusePath);
-        }
-
-
-        return true;
-    }
-
-    bool Resolver::resolvePath(const resolver::Request &req, resolver::Resolved &out) {
-        if (resolver::hasFlag(req.target, Target::Path)) {
-            if (!req.childName) {
                 log::Registry::fuse()->debug("[{}] Request target includes Child but no child name provided",
                                              req.caller);
                 out.setStatus(Status::MissingChildName, EINVAL);
                 return false;
             }
 
-            if (out.entry->path.empty()) {
-                log::Registry::fuse()->error("[{}] Failed to resolve parent path for inode {}", req.caller, *req.ino);
-                out.setStatus(Status::MissingParentPath, ENOENT);
+            out.path = out.parentEntry->path / *req.childName;
+        }
+
+        return true;
+    }
+
+    bool Resolver::resolveEntryForPath(const resolver::Request &req, resolver::Resolved &out) {
+        if (resolver::hasFlag(req.target, Target::EntryForPath)) {
+            out.entry = runtime::Deps::get().fsCache->getEntry(*out.path);
+            if (!out.entry) {
+                log::Registry::fuse()->error("[{}] Failed to resolve entry for path {}", req.caller,
+                                             out.path->string());
+                out.setStatus(Status::MissingEntry, ENOENT);
                 return false;
             }
-
-            out.path = out.entry->path / *req.childName;
-            if (!out.path || out.path->empty()) {
-                log::Registry::fuse()->error("[{}] Failed to resolve child path for parent inode {} and child name {}",
-                                             req.caller, *req.ino, *req.childName);
-                out.setStatus(Status::InvalidChildPath, ENOENT);
-                return false;
-            }
-
-            out.fusePath = out.engine->paths->absRelToAbsRel(*out.path, fs::model::PathType::VAULT_ROOT,
-                                                             fs::model::PathType::FUSE_ROOT);
-            out.ino = runtime::Deps::get().fsCache->getOrAssignInode(*out.path);
-        };
+        } else out.ino = runtime::Deps::get().fsCache->getOrAssignInode(*out.path);
 
         return true;
     }
@@ -166,10 +157,12 @@ namespace vh::fuse {
             .path = path,
             .entry = entry
         })) {
-            if (entry) log::Registry::fuse()->error("[create] Access denied for user {} on path {}", user->name,
-                                                    entry->path.string());
-            else if (path) log::Registry::fuse()->error("[create] Access denied for user {} on path {}", user->name,
-                                                        path->string());
+            if (entry)
+                log::Registry::fuse()->warn("[create] Access denied for user {} on path {}", user->name,
+                                            entry->path.string());
+            else if (path)
+                log::Registry::fuse()->warn("[create] Access denied for user {} on path {}", user->name,
+                                            path->string());
             return false;
         }
 
@@ -177,29 +170,34 @@ namespace vh::fuse {
     }
 
     bool Resolver::enforcePermissions(const resolver::Request &req, resolver::Resolved &out) {
+        const bool checkEntry =
+                resolver::hasFlag(req.target, Target::Entry) ||
+                resolver::hasFlag(req.target, Target::EntryForPath);
+
+        const bool checkPath =
+                resolver::hasFlag(req.target, Target::Path);
+
         if (req.action) {
-            if (resolver::hasFlag(req.target, Target::Entry) && !enforcePermission(out.user, *req.action, out.entry)) {
-                out.setStatus(Status::AccessDenied, EPERM);
+            if (checkEntry && !enforcePermission(out.user, *req.action, out.entry)) {
+                out.setStatus(Status::AccessDenied, EACCES);
                 return false;
             }
 
-            if (resolver::hasFlag(req.target, Target::Path) && !enforcePermission(
-                    out.user, *req.action, nullptr, out.path)) {
-                out.setStatus(Status::AccessDenied, EPERM);
+            if (checkPath && !enforcePermission(out.user, *req.action, nullptr, out.path)) {
+                out.setStatus(Status::AccessDenied, EACCES);
                 return false;
             }
         }
 
         if (!req.actions.empty()) {
             for (const auto &action: req.actions) {
-                if (resolver::hasFlag(req.target, Target::Entry) && !enforcePermission(out.user, action, out.entry)) {
-                    out.setStatus(Status::AccessDenied, EPERM);
+                if (checkEntry && !enforcePermission(out.user, action, out.entry)) {
+                    out.setStatus(Status::AccessDenied, EACCES);
                     return false;
                 }
 
-                if (resolver::hasFlag(req.target, Target::Path) && !enforcePermission(
-                        out.user, action, nullptr, out.path)) {
-                    out.setStatus(Status::AccessDenied, EPERM);
+                if (checkPath && !enforcePermission(out.user, action, nullptr, out.path)) {
+                    out.setStatus(Status::AccessDenied, EACCES);
                     return false;
                 }
             }
@@ -210,9 +208,25 @@ namespace vh::fuse {
 
     bool Resolver::resolveEngine(const resolver::Request &req, resolver::Resolved &out) {
         (void) req;
-        if (out.entry && out.entry->vault_id)
-            out.engine = runtime::Deps::get().storageManager->getEngine(*out.entry->vault_id);
 
-        return !!out.engine;
+        if (req.action || !req.actions.empty() || resolver::hasFlag(req.target, Target::Path) || resolver::hasFlag(
+                req.target, Target::EntryForPath)) {
+            if (out.entry && out.entry->vault_id)
+                out.engine = runtime::Deps::get().storageManager->getEngine(*out.entry->vault_id);
+
+            if (!out.engine && out.parentEntry && out.parentEntry->vault_id)
+                out.engine = runtime::Deps::get().storageManager->getEngine(*out.parentEntry->vault_id);
+
+            if (!out.engine && out.path)
+                out.engine = runtime::Deps::get().storageManager->resolveStorageEngine(*out.path);
+
+            if (!out.engine) {
+                out.setStatus(Status::MissingEngine, EIO);
+                return false;
+            }
+            return true;
+        }
+
+        return true;
     }
 }

--- a/src/fuse/Resolver.cpp
+++ b/src/fuse/Resolver.cpp
@@ -1,0 +1,218 @@
+#include "fuse/Resolver.hpp"
+#include "db/query/identities/User.hpp"
+#include "db/query/identities/Group.hpp"
+#include "runtime/Deps.hpp"
+#include "log/Registry.hpp"
+#include "fs/cache/Registry.hpp"
+#include "fs/model/Entry.hpp"
+#include "storage/Manager.hpp"
+#include "rbac/resolver/vault/all.hpp"
+#include "fs/model/Path.hpp"
+
+namespace vh::fuse {
+    using resolver::Target;
+    using resolver::Request;
+    using resolver::Resolved;
+    using resolver::Status;
+
+    Resolved Resolver::resolve(const Request &req) {
+        Resolved res;
+
+        if (!req.fuseReq) {
+            res.setStatus(Status::MissingFuseContext, EINVAL);
+            return res;
+        }
+
+        constexpr std::array functions{
+            resolveIdentity,
+            resolveEntry,
+            resolveEngine,
+            resolvePath,
+            enforcePermissions
+        };
+
+        for (const auto &func: functions)
+            if (!func(req, res) || !res.ok())
+                break;
+
+        return res;
+    }
+
+    bool Resolver::resolveIdentity(const resolver::Request &req, resolver::Resolved &out) {
+        const fuse_ctx *fctx = fuse_req_ctx(req.fuseReq);
+        if (!fctx) {
+            out.setStatus(Status::MissingFuseContext, EINVAL);
+            return false;
+        }
+
+        const uid_t uid = fctx->uid;
+        const gid_t gid = fctx->gid;
+
+        out.user = db::query::identities::User::getUserByLinuxUID(uid);
+        if (!out.user) {
+            log::Registry::fuse()->error("[{}] No user found for UID {}", req.caller, uid);
+            out.status = Status::MissingUser;
+            return false;
+        }
+
+        out.group = db::query::identities::Group::getGroupByLinuxGID(gid);
+
+        return true;
+    }
+
+    bool Resolver::resolveParentEntry(const resolver::Request &req, resolver::Resolved &out) {
+        if (resolver::hasFlag(req.target, Target::Path) || resolver::hasFlag(req.target, Target::EntryForPath)) {
+            if (!req.parentIno) {
+                log::Registry::fuse()->debug("[{}] Request target includes ParentEntry but no parent inode provided",
+                                             req.caller);
+                out.status = Status::MissingParentIno;
+                return false;
+            }
+
+            out.parentEntry = runtime::Deps::get().fsCache->getEntry(*req.parentIno);
+            if (!out.parentEntry) {
+                log::Registry::fuse()->error("[{}] Failed to resolve parent entry", req.caller);
+                out.setStatus(Status::MissingParentEntry, ENOENT);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool Resolver::resolveEntry(const resolver::Request &req, resolver::Resolved &out) {
+        if (resolver::hasFlag(req.target, Target::Entry)) {
+            if (!req.ino) {
+                log::Registry::fuse()->debug("[{}] Request target includes Ino but no inode provided", req.caller);
+                out.status = Status::MissingIno;
+                return false;
+            }
+
+            out.entry = runtime::Deps::get().fsCache->getEntry(*req.ino);
+            if (!out.entry) {
+                log::Registry::fuse()->error("[{}] Failed to resolve entry", req.caller);
+                out.setStatus(Status::MissingEntry, ENOENT);
+                return false;
+            }
+        } else if (resolver::hasFlag(req.target, Target::Path) || resolver::hasFlag(req.target, Target::EntryForPath)) {
+            if (!out.parentEntry) {
+                log::Registry::fuse()->error("[{}] Cannot resolve path without parent entry", req.caller);
+                out.setStatus(Status::MissingParentEntry, ENOENT);
+                return false;
+            }
+
+            if (!req.childName) {
+                log::Registry::fuse()->debug("[{}] Request target includes Child but no child name provided", req.caller);
+                out.setStatus(Status::MissingChildName, ENOENT);
+                return false;
+            }
+
+            out.path = out.parentEntry->path / *req.childName;
+            out.fusePath = out.engine->paths->absRelToAbsRel(*out.path, fs::model::PathType::VAULT_ROOT,
+                                                                 fs::model::PathType::FUSE_ROOT);
+
+            if (resolver::hasFlag(req.target, Target::EntryForPath)) {
+                out.entry = runtime::Deps::get().fsCache->getEntry(*out.fusePath);
+                if (!out.entry) {
+                    log::Registry::fuse()->error("[{}] Failed to resolve entry for path {}", req.caller, out.fusePath->string());
+                    out.setStatus(Status::MissingEntry, ENOENT);
+                    return false;
+                }
+            } else out.ino = runtime::Deps::get().fsCache->getOrAssignInode(*out.fusePath);
+        }
+
+
+        return true;
+    }
+
+    bool Resolver::resolvePath(const resolver::Request &req, resolver::Resolved &out) {
+        if (resolver::hasFlag(req.target, Target::Path)) {
+            if (!req.childName) {
+                log::Registry::fuse()->debug("[{}] Request target includes Child but no child name provided",
+                                             req.caller);
+                out.setStatus(Status::MissingChildName, EINVAL);
+                return false;
+            }
+
+            if (out.entry->path.empty()) {
+                log::Registry::fuse()->error("[{}] Failed to resolve parent path for inode {}", req.caller, *req.ino);
+                out.setStatus(Status::MissingParentPath, ENOENT);
+                return false;
+            }
+
+            out.path = out.entry->path / *req.childName;
+            if (!out.path || out.path->empty()) {
+                log::Registry::fuse()->error("[{}] Failed to resolve child path for parent inode {} and child name {}",
+                                             req.caller, *req.ino, *req.childName);
+                out.setStatus(Status::InvalidChildPath, ENOENT);
+                return false;
+            }
+
+            out.fusePath = out.engine->paths->absRelToAbsRel(*out.path, fs::model::PathType::VAULT_ROOT,
+                                                             fs::model::PathType::FUSE_ROOT);
+            out.ino = runtime::Deps::get().fsCache->getOrAssignInode(*out.path);
+        };
+
+        return true;
+    }
+
+    static bool enforcePermission(const std::shared_ptr<vh::identities::User> &user,
+                                  const rbac::permission::vault::FilesystemAction &action,
+                                  const std::shared_ptr<fs::model::Entry> &entry,
+                                  const std::optional<std::filesystem::path> &path = std::nullopt) {
+        if (!rbac::resolver::Vault::has<rbac::permission::vault::FilesystemAction>({
+            .user = user,
+            .permission = action,
+            .path = path,
+            .entry = entry
+        })) {
+            if (entry) log::Registry::fuse()->error("[create] Access denied for user {} on path {}", user->name,
+                                                    entry->path.string());
+            else if (path) log::Registry::fuse()->error("[create] Access denied for user {} on path {}", user->name,
+                                                        path->string());
+            return false;
+        }
+
+        return true;
+    }
+
+    bool Resolver::enforcePermissions(const resolver::Request &req, resolver::Resolved &out) {
+        if (req.action) {
+            if (resolver::hasFlag(req.target, Target::Entry) && !enforcePermission(out.user, *req.action, out.entry)) {
+                out.setStatus(Status::AccessDenied, EPERM);
+                return false;
+            }
+
+            if (resolver::hasFlag(req.target, Target::Path) && !enforcePermission(
+                    out.user, *req.action, nullptr, out.path)) {
+                out.setStatus(Status::AccessDenied, EPERM);
+                return false;
+            }
+        }
+
+        if (!req.actions.empty()) {
+            for (const auto &action: req.actions) {
+                if (resolver::hasFlag(req.target, Target::Entry) && !enforcePermission(out.user, action, out.entry)) {
+                    out.setStatus(Status::AccessDenied, EPERM);
+                    return false;
+                }
+
+                if (resolver::hasFlag(req.target, Target::Path) && !enforcePermission(
+                        out.user, action, nullptr, out.path)) {
+                    out.setStatus(Status::AccessDenied, EPERM);
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    bool Resolver::resolveEngine(const resolver::Request &req, resolver::Resolved &out) {
+        (void) req;
+        if (out.entry && out.entry->vault_id)
+            out.engine = runtime::Deps::get().storageManager->getEngine(*out.entry->vault_id);
+
+        return !!out.engine;
+    }
+}

--- a/src/fuse/Resolver.cpp
+++ b/src/fuse/Resolver.cpp
@@ -106,7 +106,13 @@ namespace vh::fuse {
                 return false;
             }
 
-            out.path = runtime::Deps::get().fsCache->resolvePath(*req.parentIno) / *req.childName;
+            try {
+                out.path = runtime::Deps::get().fsCache->resolvePath(*req.parentIno) / *req.childName;
+            } catch (const std::exception &e) {
+                log::Registry::fuse()->error("[{}] Failed to resolve path: {}", req.caller, e.what());
+                out.setStatus(Status::MissingPath, ENOENT);
+                return false;
+            }
         }
 
         return true;
@@ -114,6 +120,13 @@ namespace vh::fuse {
 
     bool Resolver::resolveEntryForPath(const resolver::Request &req, resolver::Resolved &out) {
         if (resolver::hasFlag(req.target, Target::EntryForPath)) {
+            if (!out.path) {
+                log::Registry::fuse()->debug("[{}] Request target includes EntryForPath but no path resolved",
+                                             req.caller);
+                out.setStatus(Status::MissingPath, EINVAL);
+                return false;
+            }
+
             out.entry = runtime::Deps::get().fsCache->getEntry(*out.path);
             if (!out.entry) {
                 log::Registry::fuse()->error("[{}] Failed to resolve entry for path {}", req.caller,

--- a/src/fuse/Resolver.cpp
+++ b/src/fuse/Resolver.cpp
@@ -26,7 +26,6 @@ namespace vh::fuse {
         constexpr std::array functions{
             resolveIdentity,
             resolveEntry,
-            resolveParentEntry,
             resolvePath,
             resolveEntryForPath,
             resolveEngine,
@@ -92,31 +91,11 @@ namespace vh::fuse {
         return true;
     }
 
-    bool Resolver::resolveParentEntry(const resolver::Request &req, resolver::Resolved &out) {
-        if (resolver::hasFlag(req.target, Target::Path) || resolver::hasFlag(req.target, Target::EntryForPath)) {
-            if (!req.parentIno) {
-                log::Registry::fuse()->debug("[{}] Request target includes ParentEntry but no parent inode provided",
-                                             req.caller);
-                out.setStatus(Status::MissingParentIno, EINVAL);
-                return false;
-            }
-
-            out.parentEntry = runtime::Deps::get().fsCache->getEntry(*req.parentIno);
-            if (!out.parentEntry) {
-                log::Registry::fuse()->debug("[{}] Failed to resolve parent entry", req.caller);
-                out.setStatus(Status::MissingParentEntry, ENOENT);
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     bool Resolver::resolvePath(const resolver::Request &req, resolver::Resolved &out) {
         if (resolver::hasFlag(req.target, Target::Path) || resolver::hasFlag(req.target, Target::EntryForPath)) {
-            if (!out.parentEntry) {
-                log::Registry::fuse()->error("[{}] Cannot resolve path without parent entry", req.caller);
-                out.setStatus(Status::MissingParentEntry, ENOENT);
+            if (!req.parentIno) {
+                log::Registry::fuse()->debug("[{}] Request target includes Path but no parent inode provided", req.caller);
+                out.setStatus(Status::MissingParentIno, EINVAL);
                 return false;
             }
 
@@ -127,7 +106,7 @@ namespace vh::fuse {
                 return false;
             }
 
-            out.path = out.parentEntry->path / *req.childName;
+            out.path = runtime::Deps::get().fsCache->resolvePath(*req.parentIno) / *req.childName;
         }
 
         return true;
@@ -183,7 +162,7 @@ namespace vh::fuse {
                 return false;
             }
 
-            if (checkPath && !enforcePermission(out.user, *req.action, nullptr, out.path)) {
+            if (checkPath && !enforcePermission(out.user, *req.action, nullptr, out.vaultPath)) {
                 out.setStatus(Status::AccessDenied, EACCES);
                 return false;
             }
@@ -196,7 +175,7 @@ namespace vh::fuse {
                     return false;
                 }
 
-                if (checkPath && !enforcePermission(out.user, action, nullptr, out.path)) {
+                if (checkPath && !enforcePermission(out.user, action, nullptr, out.vaultPath)) {
                     out.setStatus(Status::AccessDenied, EACCES);
                     return false;
                 }
@@ -214,12 +193,10 @@ namespace vh::fuse {
             if (out.entry && out.entry->vault_id)
                 out.engine = runtime::Deps::get().storageManager->getEngine(*out.entry->vault_id);
 
-            if (!out.engine && out.parentEntry && out.parentEntry->vault_id)
-                out.engine = runtime::Deps::get().storageManager->getEngine(*out.parentEntry->vault_id);
-
             if (!out.engine && out.path)
                 out.engine = runtime::Deps::get().storageManager->resolveStorageEngine(*out.path);
 
+            if (out.engine && out.path) out.vaultPath = out.engine->paths->absRelToAbsRel(*out.path, fs::model::PathType::FUSE_ROOT, fs::model::PathType::FUSE_ROOT);
             if (!out.engine) {
                 out.setStatus(Status::MissingEngine, EIO);
                 return false;

--- a/src/identities/User.cpp
+++ b/src/identities/User.cpp
@@ -138,7 +138,7 @@ namespace vh::identities {
         return roles.admin->keys.encryptionKeys;
     }
 
-    std::shared_ptr<Vault> User::getDirectVaultRole(const uint32_t vaultId) const {
+    std::shared_ptr<rbac::role::Vault> User::getDirectVaultRole(const uint32_t vaultId) const {
         std::scoped_lock lock(mutex_);
 
         const auto it = roles.vaults.find(vaultId);

--- a/src/protocols/shell/commands/vault/create.cpp
+++ b/src/protocols/shell/commands/vault/create.cpp
@@ -15,11 +15,7 @@
 #include "sync/model/LocalPolicy.hpp"
 #include "sync/model/RemotePolicy.hpp"
 #include "identities/User.hpp"
-
-#include "log/Registry.hpp"
-#include "config/Registry.hpp"
 #include "db/encoding/interval.hpp"
-
 #include "rbac/resolver/admin/all.hpp"
 
 #include <algorithm>
@@ -31,7 +27,6 @@
 
 using namespace vh;
 using namespace vh::protocols::shell;
-using namespace vh::protocols::shell::commands::vault;
 
 static constexpr const auto* SYNC_STRATEGY_HELP = R"(
 Sync Strategy Options:
@@ -84,174 +79,176 @@ Sync Interval:
   Default is 15 minutes (15m).
 )";
 
-static CommandResult finish_vault_create(const CommandCall& call, std::shared_ptr<vault::model::Vault>& v,
-                                         const std::shared_ptr<sync::model::Policy>& s) {
-    try {
-        const auto [okToProceed, waiver] = handle_encryption_waiver({call, v, false});
-        if (!okToProceed) return invalid("vault create: user did not accept encryption waiver");
+namespace vh::protocols::shell::commands::vault {
+    static CommandResult finish_vault_create(const CommandCall& call, std::shared_ptr<vh::vault::model::Vault>& v,
+                                             const std::shared_ptr<sync::model::Policy>& s) {
+        try {
+            const auto [okToProceed, waiver] = handle_encryption_waiver({call, v, false});
+            if (!okToProceed) return invalid("vault create: user did not accept encryption waiver");
 
-        v = vh::runtime::Deps::get().storageManager->addVault(v, s);
-        if (waiver) db::query::vault::Waiver::addWaiver(waiver);
+            v = vh::runtime::Deps::get().storageManager->addVault(v, s);
+            if (waiver) db::query::vault::Waiver::addWaiver(waiver);
 
-        return ok("\nSuccessfully created new vault!\n" + to_string(v));
-    } catch (const std::exception& e) {
-        if (db::query::vault::Vault::vaultExists(v->name, v->owner_id))
-            vh::runtime::Deps::get().storageManager->removeVault(v->id);
+            return ok("\nSuccessfully created new vault!\n" + to_string(v));
+        } catch (const std::exception& e) {
+            if (db::query::vault::Vault::vaultExists(v->name, v->owner_id))
+                vh::runtime::Deps::get().storageManager->removeVault(v->id);
 
-        return invalid("\nvault create error: " + std::string(e.what()) + "\n");
-    }
-}
-
-static std::string stripLeadingDashes(const std::string& s) {
-    size_t pos = 0;
-    while (pos < s.size() && s[pos] == '-') ++pos;
-    return s.substr(pos);
-}
-
-static CommandResult handle_vault_create_interactive(const CommandCall& call) {
-    const auto& io = call.io;
-
-    std::shared_ptr<vault::model::Vault> v;
-    std::shared_ptr<sync::model::Policy> sync;
-
-    const auto helpOptions = std::vector<std::string>{"help", "h", "?"};
-
-    const auto usage = resolveUsage({"vault", "create"});
-    validatePositionals(call, usage);
-
-    const auto type = io->prompt("Select vault type (local/s3) [local]:", "local");
-    if (type == "local") {
-        v = std::make_shared<vh::vault::model::Vault>();
-        v->type = vault::model::VaultType::Local;
-    } else if (type == "s3") {
-        v = std::make_shared<vault::model::S3Vault>();
-        v->type = vault::model::VaultType::S3;
-    } else return invalid("vault create: invalid vault type");
-
-    v->name = io->prompt("Enter vault name (required):");
-    if (v->name.empty()) return invalid("vault create: vault name is required");
-
-    v->description = io->prompt("Enter vault description (optional):");
-
-    const auto quotaStr = io->prompt("Enter vault quota (e.g. 10G, 500M) or leave blank for unlimited:");
-    v->quota = quotaStr.empty() ? 0 : parseSize(quotaStr);
-
-    const auto ownerPrompt = io->prompt("Enter owner user ID or username (leave blank for yourself):");
-    const auto owner = resolveOwner(call, usage);
-    v->owner_id = owner->id;
-
-    if (v->owner_id != call.user->id) {
-        // TODO: vault/global perm scoping
-    }
-
-    if (v->type == vault::model::VaultType::Local) {
-        auto fSync = std::make_shared<sync::model::LocalPolicy>();
-
-        auto conflictStr = io->prompt(
-            "Enter on-sync-conflict policy (overwrite/keep_both/ask) [overwrite] --help for details:", "overwrite");
-        while (conflictStr == "help") {
-            io->print(LOCAL_CONFLICT_POLICY_HELP);
-            conflictStr = io->prompt("Enter on-sync-conflict policy (overwrite/keep_both/ask) [overwrite]:",
-                                     "overwrite");
+            return invalid("\nvault create error: " + std::string(e.what()) + "\n");
         }
-        fSync->conflict_policy = sync::model::fsConflictPolicyFromString(conflictStr);
-        sync = fSync;
     }
 
-    if (v->type == vault::model::VaultType::S3) {
-        const auto s3Vault = std::static_pointer_cast<vault::model::S3Vault>(v);
-        const auto apiKeyStr = io->prompt("Enter API key name or ID (required):");
-        if (apiKeyStr.empty()) return invalid("vault create: API key is required for S3 vaults");
+    static std::string stripLeadingDashes(const std::string& s) {
+        size_t pos = 0;
+        while (pos < s.size() && s[pos] == '-') ++pos;
+        return s.substr(pos);
+    }
 
-        std::shared_ptr<vault::model::APIKey> apiKey;
-        if (const auto apiKeyIdOpt = parseUInt(apiKeyStr)) apiKey = db::query::vault::APIKey::getAPIKey(*apiKeyIdOpt);
-        else apiKey = db::query::vault::APIKey::getAPIKey(apiKeyStr);
+    static CommandResult handle_vault_create_interactive(const CommandCall& call) {
+        const auto& io = call.io;
 
-        if (!apiKey) return invalid("vault create: API key not found: " + apiKeyStr);
+        std::shared_ptr<vh::vault::model::Vault> v;
+        std::shared_ptr<sync::model::Policy> sync;
 
-        using Perm = rbac::permission::admin::keys::APIPermissions;
-        if (!rbac::resolver::Admin::has<Perm>({
+        const auto helpOptions = std::vector<std::string>{"help", "h", "?"};
+
+        const auto usage = resolveUsage({"vault", "create"});
+        validatePositionals(call, usage);
+
+        const auto type = io->prompt("Select vault type (local/s3) [local]:", "local");
+        if (type == "local") {
+            v = std::make_shared<vh::vault::model::Vault>();
+            v->type = vh::vault::model::VaultType::Local;
+        } else if (type == "s3") {
+            v = std::make_shared<vh::vault::model::S3Vault>();
+            v->type = vh::vault::model::VaultType::S3;
+        } else return invalid("vault create: invalid vault type");
+
+        v->name = io->prompt("Enter vault name (required):");
+        if (v->name.empty()) return invalid("vault create: vault name is required");
+
+        v->description = io->prompt("Enter vault description (optional):");
+
+        const auto quotaStr = io->prompt("Enter vault quota (e.g. 10G, 500M) or leave blank for unlimited:");
+        v->quota = quotaStr.empty() ? 0 : parseSize(quotaStr);
+
+        const auto ownerPrompt = io->prompt("Enter owner user ID or username (leave blank for yourself):");
+        const auto owner = resolveOwner(call, usage);
+        v->owner_id = owner->id;
+
+        if (v->owner_id != call.user->id) {
+            // TODO: vault/global perm scoping
+        }
+
+        if (v->type == vh::vault::model::VaultType::Local) {
+            auto fSync = std::make_shared<sync::model::LocalPolicy>();
+
+            auto conflictStr = io->prompt(
+                "Enter on-sync-conflict policy (overwrite/keep_both/ask) [overwrite] --help for details:", "overwrite");
+            while (conflictStr == "help") {
+                io->print(LOCAL_CONFLICT_POLICY_HELP);
+                conflictStr = io->prompt("Enter on-sync-conflict policy (overwrite/keep_both/ask) [overwrite]:",
+                                         "overwrite");
+            }
+            fSync->conflict_policy = sync::model::fsConflictPolicyFromString(conflictStr);
+            sync = fSync;
+        }
+
+        if (v->type == vh::vault::model::VaultType::S3) {
+            const auto s3Vault = std::static_pointer_cast<vh::vault::model::S3Vault>(v);
+            const auto apiKeyStr = io->prompt("Enter API key name or ID (required):");
+            if (apiKeyStr.empty()) return invalid("vault create: API key is required for S3 vaults");
+
+            std::shared_ptr<vh::vault::model::APIKey> apiKey;
+            if (const auto apiKeyIdOpt = parseUInt(apiKeyStr)) apiKey = db::query::vault::APIKey::getAPIKey(*apiKeyIdOpt);
+            else apiKey = db::query::vault::APIKey::getAPIKey(apiKeyStr);
+
+            if (!apiKey) return invalid("vault create: API key not found: " + apiKeyStr);
+
+            using Perm = rbac::permission::admin::keys::APIPermissions;
+            if (!rbac::resolver::Admin::has<Perm>({
+                .user = call.user,
+                .permission = Perm::Consume,
+                .api_key_id = apiKey->id
+            })) return invalid("vault create: user does not have permission to consume API key ID " + std::to_string(apiKey->id));
+
+            s3Vault->api_key_id = apiKey->id;
+
+            s3Vault->bucket = io->prompt("Enter S3 bucket name (required):");
+            if (s3Vault->bucket.empty()) return invalid("vault create: S3 bucket name is required");
+
+            auto strategyStr = io->prompt("Enter sync strategy (cache/sync/mirror) [cache] --help for details:",
+                                          "cache");
+            while (std::ranges::find(helpOptions.begin(), helpOptions.end(), stripLeadingDashes(strategyStr)) !=
+                   helpOptions.end()) {
+                io->print(SYNC_STRATEGY_HELP);
+                strategyStr = io->prompt("Enter sync strategy (cache/sync/mirror) [cache]:", "cache");
+                   }
+            const auto rsync = std::make_shared<sync::model::RemotePolicy>();
+            rsync->strategy = sync::model::strategyFromString(strategyStr);
+
+            auto conflictStr = io->prompt(
+                "Enter on-sync-conflict policy (keep_local/keep_remote/ask) [ask] --help for details:", "ask");
+            while (std::ranges::find(helpOptions.begin(), helpOptions.end(), stripLeadingDashes(conflictStr)) !=
+                   helpOptions.end()) {
+                io->print(REMOTE_CONFLICT_POLICY_HELP);
+                conflictStr = io->prompt("Enter on-sync-conflict policy (keep_local/keep_remote/ask) [ask]:", "ask");
+                   }
+            rsync->conflict_policy = sync::model::rsConflictPolicyFromString(conflictStr);
+
+            sync = rsync;
+
+            s3Vault->encrypt_upstream = io->confirm("Enable upstream encryption? (yes/no) [yes]", false);
+        }
+
+        auto interval = io->prompt("Enter sync interval (e.g. 30s, 10m, 1h) [15m] --help for details:", "15m");
+        while (std::ranges::find(helpOptions.begin(), helpOptions.end(), stripLeadingDashes(interval)) != helpOptions.
+               end()) {
+            io->print(SYNC_INTERVAL_HELP);
+            interval = io->prompt("Enter sync interval (e.g. 30s, 10m, 1h) [15m]:", "15m");
+               }
+        sync->interval = db::encoding::parseSyncInterval(interval);
+
+        return finish_vault_create(call, v, sync);
+    }
+
+    CommandResult handle_vault_create(const CommandCall& call) {
+        if (hasFlag(call, "interactive")) return handle_vault_create_interactive(call);
+
+        const auto usage = resolveUsage({"vault", "create"});
+        validatePositionals(call, usage);
+        const auto owner = resolveOwner(call, usage);
+
+        using VPerm = rbac::permission::admin::VaultPermissions;
+        if (!rbac::resolver::Admin::has<VPerm>({
             .user = call.user,
-            .permission = Perm::Consume,
-            .api_key_id = apiKey->id
-        })) return invalid("vault create: user does not have permission to consume API key ID " + std::to_string(apiKey->id));
+            .permission = VPerm::Create,
+            .target_user_id = owner->id
+        })) return invalid("vault create: user does not have permission to create vaults for user ID " + std::to_string(owner->id));
 
-        s3Vault->api_key_id = apiKey->id;
+        const auto type = parseVaultType(call);
+        std::shared_ptr<vh::vault::model::Vault> vault;
+        if (*type == vh::vault::model::VaultType::Local) vault = std::make_shared<vh::vault::model::Vault>();
+        else if (*type == vh::vault::model::VaultType::S3) vault = std::make_shared<vh::vault::model::S3Vault>();
+        else return invalid("vault create: unknown vault type");
 
-        s3Vault->bucket = io->prompt("Enter S3 bucket name (required):");
-        if (s3Vault->bucket.empty()) return invalid("vault create: S3 bucket name is required");
+        vault->type = *type;
+        vault->name = call.positionals[0];
+        vault->owner_id = owner->id;
+        assignDescIfAvailable(call, usage, vault);
+        assignQuotaIfAvailable(call, usage, vault);
 
-        auto strategyStr = io->prompt("Enter sync strategy (cache/sync/mirror) [cache] --help for details:",
-                                      "cache");
-        while (std::ranges::find(helpOptions.begin(), helpOptions.end(), stripLeadingDashes(strategyStr)) !=
-               helpOptions.end()) {
-            io->print(SYNC_STRATEGY_HELP);
-            strategyStr = io->prompt("Enter sync strategy (cache/sync/mirror) [cache]:", "cache");
-               }
-        const auto rsync = std::make_shared<sync::model::RemotePolicy>();
-        rsync->strategy = sync::model::strategyFromString(strategyStr);
+        if (db::query::vault::Vault::vaultExists(vault->name, owner->id)) return invalid(
+            "vault create: vault with name '" + vault->name + "' already exists for user ID " + std::to_string(owner->id));
 
-        auto conflictStr = io->prompt(
-            "Enter on-sync-conflict policy (keep_local/keep_remote/ask) [ask] --help for details:", "ask");
-        while (std::ranges::find(helpOptions.begin(), helpOptions.end(), stripLeadingDashes(conflictStr)) !=
-               helpOptions.end()) {
-            io->print(REMOTE_CONFLICT_POLICY_HELP);
-            conflictStr = io->prompt("Enter on-sync-conflict policy (keep_local/keep_remote/ask) [ask]:", "ask");
-               }
-        rsync->conflict_policy = sync::model::rsConflictPolicyFromString(conflictStr);
+        std::shared_ptr<sync::model::Policy> sync;
+        if (vault->type == vh::vault::model::VaultType::Local) sync = std::make_shared<sync::model::LocalPolicy>();
+        else if (vault->type == vh::vault::model::VaultType::S3) sync = std::make_shared<sync::model::RemotePolicy>();
+        else return invalid("vault create: unknown vault type");
 
-        sync = rsync;
+        parseSync(call, usage, vault, sync);
+        parseS3API(call, usage, vault, true);
 
-        s3Vault->encrypt_upstream = io->confirm("Enable upstream encryption? (yes/no) [yes]", false);
+        return finish_vault_create(call, vault, sync);
     }
-
-    auto interval = io->prompt("Enter sync interval (e.g. 30s, 10m, 1h) [15m] --help for details:", "15m");
-    while (std::ranges::find(helpOptions.begin(), helpOptions.end(), stripLeadingDashes(interval)) != helpOptions.
-           end()) {
-        io->print(SYNC_INTERVAL_HELP);
-        interval = io->prompt("Enter sync interval (e.g. 30s, 10m, 1h) [15m]:", "15m");
-           }
-    sync->interval = db::encoding::parseSyncInterval(interval);
-
-    return finish_vault_create(call, v, sync);
-}
-
-CommandResult commands::vault::handle_vault_create(const CommandCall& call) {
-    if (hasFlag(call, "interactive")) return handle_vault_create_interactive(call);
-
-    const auto usage = resolveUsage({"vault", "create"});
-    validatePositionals(call, usage);
-    const auto owner = resolveOwner(call, usage);
-
-    using VPerm = rbac::permission::admin::VaultPermissions;
-    if (!rbac::resolver::Admin::has<VPerm>({
-        .user = call.user,
-        .permission = VPerm::Create,
-        .target_user_id = owner->id
-    })) return invalid("vault create: user does not have permission to create vaults for user ID " + std::to_string(owner->id));
-
-    const auto type = parseVaultType(call);
-    std::shared_ptr<vh::vault::model::Vault> vault;
-    if (*type == vh::vault::model::VaultType::Local) vault = std::make_shared<vh::vault::model::Vault>();
-    else if (*type == vh::vault::model::VaultType::S3) vault = std::make_shared<vh::vault::model::S3Vault>();
-    else return invalid("vault create: unknown vault type");
-
-    vault->type = *type;
-    vault->name = call.positionals[0];
-    vault->owner_id = owner->id;
-    assignDescIfAvailable(call, usage, vault);
-    assignQuotaIfAvailable(call, usage, vault);
-
-    if (db::query::vault::Vault::vaultExists(vault->name, owner->id)) return invalid(
-        "vault create: vault with name '" + vault->name + "' already exists for user ID " + std::to_string(owner->id));
-
-    std::shared_ptr<sync::model::Policy> sync;
-    if (vault->type == vh::vault::model::VaultType::Local) sync = std::make_shared<sync::model::LocalPolicy>();
-    else if (vault->type == vh::vault::model::VaultType::S3) sync = std::make_shared<sync::model::RemotePolicy>();
-    else return invalid("vault create: unknown vault type");
-
-    parseSync(call, usage, vault, sync);
-    parseS3API(call, usage, vault, true);
-
-    return finish_vault_create(call, vault, sync);
 }

--- a/src/protocols/ws/handler/fs/Upload.cpp
+++ b/src/protocols/ws/handler/fs/Upload.cpp
@@ -25,7 +25,8 @@ namespace vh::protocols::ws::handler::fs {
         if (std::filesystem::is_directory(args.finalPath))
             throw std::runtime_error("Upload final path is a directory — filename must be provided");
 
-        Filesystem::mkdir(args.fuseFrom.parent_path(), 0755, session_->user->id, args.engine);
+        if (const auto err = Filesystem::mkdir(args.fuseFrom.parent_path(), 0755, session_->user->id, args.engine); err)
+            throw std::runtime_error(std::string("Failed to create directory ") + args.fuseFrom.parent_path().string());
 
         currentUpload_.emplace(args);
     }
@@ -58,7 +59,10 @@ namespace vh::protocols::ws::handler::fs {
         log::Registry::ws()->debug("[UploadHandler] Finishing upload (uploadId: {}, fuseFrom: {}, fuseTo: {}, userId: {})",
                                  upload.uploadId, upload.fuseFrom.string(), upload.fuseTo.string(), session_->user->id);
 
-        Filesystem::rename(upload.fuseFrom, upload.fuseTo, session_->user->id, upload.engine);
+        if (const auto err = Filesystem::rename(upload.fuseFrom, upload.fuseTo, session_->user->id, upload.engine); err) {
+            std::filesystem::remove(upload.tmpPath);
+            throw std::runtime_error(std::string("Failed to move uploaded file to final location: ") + std::strerror(err));
+        }
 
         currentUpload_.reset();
     }

--- a/src/storage/Engine.cpp
+++ b/src/storage/Engine.cpp
@@ -131,7 +131,9 @@ namespace vh::storage {
                 continue;
             }
 
-            Filesystem::mkdir(toPath.parent_path());
+            if (const auto err = Filesystem::mkdir(toPath.parent_path()); err)
+                throw std::runtime_error("Failed to create thumbnail directory: " + toPath.parent_path().string() + " Error: " + std::to_string(err));
+
             fs::rename(fromPath, toPath);
         }
     }
@@ -151,32 +153,38 @@ namespace vh::storage {
                 continue;
             }
 
-            Filesystem::mkdir(toPath.parent_path());
+            if (const auto err = Filesystem::mkdir(toPath.parent_path()); err)
+                throw std::runtime_error("Failed to create thumbnail directory: " + toPath.parent_path().string() + " Error: " + std::to_string(err));
+
             fs::copy_file(fromPath, toPath, fs::copy_options::overwrite_existing);
         }
     }
 
     void Engine::mkdir(const fs::path &relPath, const unsigned int userId) {
-        Filesystem::mkdir(paths->absRelToAbsRel(relPath, PathType::VAULT_ROOT, PathType::FUSE_ROOT), 0755, userId,
-                          shared_from_this());
+        if (const auto err = Filesystem::mkdir(paths->absRelToAbsRel(relPath, PathType::VAULT_ROOT, PathType::FUSE_ROOT), 0755, userId,
+                          shared_from_this()); err)
+            throw std::runtime_error("Failed to create directory: " + relPath.string());
     }
 
     void Engine::move(const fs::path &from, const fs::path &to, const unsigned int userId) {
-        Filesystem::rename(paths->absRelToAbsRel(from, PathType::VAULT_ROOT, PathType::FUSE_ROOT),
+        if (const auto err = Filesystem::rename(paths->absRelToAbsRel(from, PathType::VAULT_ROOT, PathType::FUSE_ROOT),
                            paths->absRelToAbsRel(to, PathType::VAULT_ROOT, PathType::FUSE_ROOT), userId,
-                           shared_from_this());
+                           shared_from_this()); err)
+            throw std::runtime_error("Failed to move directory: " + from.string() + " to " + to.string());
     }
 
     void Engine::rename(const fs::path &from, const fs::path &to, const unsigned int userId) {
-        Filesystem::rename(paths->absRelToAbsRel(from, PathType::VAULT_ROOT, PathType::FUSE_ROOT),
+        if (const auto err = Filesystem::rename(paths->absRelToAbsRel(from, PathType::VAULT_ROOT, PathType::FUSE_ROOT),
                            paths->absRelToAbsRel(to, PathType::VAULT_ROOT, PathType::FUSE_ROOT), userId,
-                           shared_from_this());
+                           shared_from_this()); err)
+            throw std::runtime_error("Failed to rename: " + from.string() + " to " + to.string());
     }
 
     void Engine::copy(const fs::path &from, const fs::path &to, const unsigned int userId) {
-        Filesystem::copy(paths->absRelToAbsRel(from, PathType::VAULT_ROOT, PathType::FUSE_ROOT),
+        if (const auto err = Filesystem::copy(paths->absRelToAbsRel(from, PathType::VAULT_ROOT, PathType::FUSE_ROOT),
                          paths->absRelToAbsRel(to, PathType::VAULT_ROOT, PathType::FUSE_ROOT), userId,
-                         shared_from_this());
+                         shared_from_this()); err)
+            throw std::runtime_error("Failed to copy: " + from.string() + " to " + to.string());
     }
 
     void Engine::remove(const fs::path &rel_path, const unsigned int userId) const {

--- a/src/storage/s3/Controller.cpp
+++ b/src/storage/s3/Controller.cpp
@@ -8,103 +8,104 @@
 #include <sstream>
 #include <utility>
 
-using namespace vh::storage::s3;
 using namespace vh::vault::model;
 using namespace vh::storage::s3::curl;
 
-Controller::Controller(const std::shared_ptr<APIKey>& apiKey, std::string bucket)
-: apiKey_(apiKey), bucket_(std::move(bucket)) {
-    if (!apiKey_) throw std::runtime_error("S3Provider requires a valid S3APIKey");
-    ensureCurlGlobalInit();
-}
-
-Controller::~Controller() = default;
-
-void Controller::deleteObject(const fs::path& key) const {
-    const CurlEasy tmpHandle;
-    const auto [canonical, url] = constructPaths(static_cast<CURL*>(tmpHandle), key);
-
-    const std::string payloadHash = sha256Hex("");
-    const SList hdrs = makeSigHeaders("DELETE", canonical, payloadHash);
-
-    HttpResponse resp = performCurl([&](CURL* h){
-        curl_easy_setopt(h, CURLOPT_URL, url.c_str());
-        curl_easy_setopt(h, CURLOPT_CUSTOMREQUEST, "DELETE");
-        curl_easy_setopt(h, CURLOPT_HTTPHEADER, hdrs.get());
-    });
-
-    if (!resp.ok()) log::Registry::cloud()->error(
-        "[S3Provider] deleteObject failed: CURL={} HTTP={} Response:\n{}",
-        resp.curl, resp.http, resp.body
-    );
-
-    if (!resp.ok()) throw std::runtime_error(
-        fmt::format("Failed to delete object from S3 (HTTP {}): {}", resp.http, resp.body));
-}
-
-std::u8string Controller::listObjects(const fs::path& prefix) const {
-    std::u8string fullXmlResponse;
-    std::string continuationToken;
-    bool moreResults = true;
-
-    while (moreResults) {
-        CURL* curl = curl_easy_init();
-        if (!curl) break;
-
-        std::string escapedPrefix;
-        if (!prefix.empty()) escapedPrefix = escapeKeyPreserveSlashes(curl, prefix);
-
-        std::ostringstream uri;
-        uri << "/" << bucket_ << "?list-type=2";
-        if (!escapedPrefix.empty()) uri << "&prefix=" << escapedPrefix;
-        if (!continuationToken.empty()) {
-            char* escapedToken = curl_easy_escape(curl, continuationToken.c_str(), static_cast<int>(continuationToken.size()));
-            if (!escapedToken) {
-                curl_easy_cleanup(curl);
-                break;
-            }
-            uri << "&continuation-token=" << escapedToken;
-            curl_free(escapedToken);
-        }
-
-        const std::string uriStr = uri.str();
-        const std::string url = apiKey_->endpoint + uriStr;
-
-        const std::string payloadHash = "UNSIGNED-PAYLOAD";
-        const auto hdrMap = buildHeaderMap(payloadHash);
-        const std::string authHeader =  buildAuthorizationHeader(apiKey_, "GET", uriStr, hdrMap, payloadHash);
-
-        HeaderList headers;
-        headers.add("Authorization: " + authHeader);
-        for (const auto& [k, v] : hdrMap) headers.add(k + ": " + v);
-
-        std::string response;
-        curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers.list);
-        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeToString);
-        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
-
-        const CURLcode res = curl_easy_perform(curl);
-        curl_easy_cleanup(curl);
-
-        if (res != CURLE_OK) {
-            log::Registry::cloud()->error("[S3Provider] listObjects failed: CURL={} Response:\n{}",
-                                        res, response);
-            break;
-        }
-
-        // Append raw XML as UTF-8
-        fullXmlResponse += std::u8string(reinterpret_cast<const char8_t*>(response.data()), response.size());
-
-        parsePagination(response, continuationToken, moreResults);
+namespace vh::storage::s3 {
+    Controller::Controller(const std::shared_ptr<APIKey>& apiKey, std::string bucket)
+    : apiKey_(apiKey), bucket_(std::move(bucket)) {
+        if (!apiKey_) throw std::runtime_error("S3Provider requires a valid S3APIKey");
+        ensureCurlGlobalInit();
     }
 
-    return fullXmlResponse;
-}
+    Controller::~Controller() = default;
 
-std::pair<std::string, std::string> Controller::constructPaths(CURL* curl, const fs::path& p, const std::string& query) const {
-    const auto escapedKey = escapeKeyPreserveSlashes(curl, p);
-    const auto canonicalPath = "/" + bucket_ + "/" + escapedKey + query;
-    const auto url = apiKey_->endpoint + canonicalPath;
-    return {canonicalPath, url};
+    void Controller::deleteObject(const fs::path& key) const {
+        const CurlEasy tmpHandle;
+        const auto [canonical, url] = constructPaths(static_cast<CURL*>(tmpHandle), key);
+
+        const std::string payloadHash = sha256Hex("");
+        const SList hdrs = makeSigHeaders("DELETE", canonical, payloadHash);
+
+        HttpResponse resp = performCurl([&](CURL* h){
+            curl_easy_setopt(h, CURLOPT_URL, url.c_str());
+            curl_easy_setopt(h, CURLOPT_CUSTOMREQUEST, "DELETE");
+            curl_easy_setopt(h, CURLOPT_HTTPHEADER, hdrs.get());
+        });
+
+        if (!resp.ok()) log::Registry::cloud()->error(
+            "[S3Provider] deleteObject failed: CURL={} HTTP={} Response:\n{}",
+            resp.curl, resp.http, resp.body
+        );
+
+        if (!resp.ok()) throw std::runtime_error(
+            fmt::format("Failed to delete object from S3 (HTTP {}): {}", resp.http, resp.body));
+    }
+
+    std::u8string Controller::listObjects(const fs::path& prefix) const {
+        std::u8string fullXmlResponse;
+        std::string continuationToken;
+        bool moreResults = true;
+
+        while (moreResults) {
+            CURL* curl = curl_easy_init();
+            if (!curl) break;
+
+            std::string escapedPrefix;
+            if (!prefix.empty()) escapedPrefix = escapeKeyPreserveSlashes(curl, prefix);
+
+            std::ostringstream uri;
+            uri << "/" << bucket_ << "?list-type=2";
+            if (!escapedPrefix.empty()) uri << "&prefix=" << escapedPrefix;
+            if (!continuationToken.empty()) {
+                char* escapedToken = curl_easy_escape(curl, continuationToken.c_str(), static_cast<int>(continuationToken.size()));
+                if (!escapedToken) {
+                    curl_easy_cleanup(curl);
+                    break;
+                }
+                uri << "&continuation-token=" << escapedToken;
+                curl_free(escapedToken);
+            }
+
+            const std::string uriStr = uri.str();
+            const std::string url = apiKey_->endpoint + uriStr;
+
+            const std::string payloadHash = "UNSIGNED-PAYLOAD";
+            const auto hdrMap = buildHeaderMap(payloadHash);
+            const std::string authHeader =  buildAuthorizationHeader(apiKey_, "GET", uriStr, hdrMap, payloadHash);
+
+            HeaderList headers;
+            headers.add("Authorization: " + authHeader);
+            for (const auto& [k, v] : hdrMap) headers.add(k + ": " + v);
+
+            std::string response;
+            curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+            curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers.list);
+            curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeToString);
+            curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+
+            const CURLcode res = curl_easy_perform(curl);
+            curl_easy_cleanup(curl);
+
+            if (res != CURLE_OK) {
+                log::Registry::cloud()->error("[S3Provider] listObjects failed: CURL={} Response:\n{}",
+                                            res, response);
+                break;
+            }
+
+            // Append raw XML as UTF-8
+            fullXmlResponse += std::u8string(reinterpret_cast<const char8_t*>(response.data()), response.size());
+
+            parsePagination(response, continuationToken, moreResults);
+        }
+
+        return fullXmlResponse;
+    }
+
+    std::pair<std::string, std::string> Controller::constructPaths(CURL* curl, const fs::path& p, const std::string& query) const {
+        const auto escapedKey = escapeKeyPreserveSlashes(curl, p);
+        const auto canonicalPath = "/" + bucket_ + "/" + escapedKey + query;
+        const auto url = apiKey_->endpoint + canonicalPath;
+        return {canonicalPath, url};
+    }
 }

--- a/src/sync/Local.cpp
+++ b/src/sync/Local.cpp
@@ -184,7 +184,9 @@ void Local::processOperations() const {
 
         const auto absSrc = engine->paths->absPath(op->source_path, PathType::BACKING_VAULT_ROOT);
         const auto absDest = engine->paths->absPath(op->destination_path, PathType::BACKING_VAULT_ROOT);
-        if (absDest.has_parent_path()) Filesystem::mkdir(absDest.parent_path());
+        if (absDest.has_parent_path())
+            if (const auto err = Filesystem::mkdir(absDest.parent_path()); err)
+                handleError(std::format("[FSTask] Failed to create parent directory for '{}': {}", absDest.parent_path().string(), std::strerror(err)));
 
         const auto f = db::query::fs::File::getFileByPath(engine->vault->id, op->destination_path);
         if (!f) {


### PR DESCRIPTION
## Summary

Refactors the FUSE layer to centralize request resolution, remove exception-based control flow, and significantly reduce handler complexity.

## Key Changes

### 🔧 fuse::Resolver
- Introduced `fuse::Resolver` to handle:
  - identity resolution (user/group)
  - entry / parent / path resolution
  - storage engine resolution
  - RBAC enforcement
- Handlers now declare intent via `Request` instead of manually resolving dependencies

### ⚙️ Error Handling (no exceptions)
- Refactored `fs::Filesystem` to return error codes instead of throwing
- Removed all `try/catch` blocks from FUSE handlers
- Standardized error propagation via resolver + errno

### 🧼 Bridge Simplification
- Reduced `fuse::Bridge` from ~1000 LOC → ~600 LOC
- Eliminated repeated boilerplate:
  - user lookup
  - entry/path resolution
  - permission checks
  - error handling patterns

## Example

Before:
- Handlers manually resolved user, entry, path, permissions
- Multiple early returns and try/catch blocks per function

After:
```cpp
const auto resolved = Resolver::resolve({
    .caller = "mkdir",
    .fuseReq = req,
    .parentIno = parent,
    .childName = name,
    .action = permission::vault::FilesystemAction::Touch,
    .target = resolver::Target::Path
});

if (!resolved.ok()) {
    fuse_reply_err(req, resolved.errnum);
    return;
}